### PR TITLE
Bugfix/31 post qt6 double delete on program exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,12 +122,11 @@ set(CMAKE_AUTOUIC ON)
 find_package(PkgConfig REQUIRED) # @note I see PkgConfig just before ECM in a few KDE scripts.
 find_package(ECM ${ECM_MIN_VERSION} REQUIRED NO_MODULE)
 
-# Add dirs where we keep support *.cmake's, ucm, cotire, ECM, etc.
+# Add dirs where we keep support *.cmake's, ucm, ECM, etc.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake
-		#${CMAKE_SOURCE_DIR}/cmake/cotire/CMake
 		${CMAKE_SOURCE_DIR}/cmake/ucm/cmake
 		${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR}
-		${CMAKE_SOURCE_DIR}/src/third_party/continuable/cmake)
+)
 
 ###
 ### ECM Macros
@@ -163,7 +162,7 @@ include(ECMQtDeclareLoggingCategory)
 # "leak" requires the "address" sanitizer.
 ### @note KDECompileFlags includes include(ECMEnableSanitizers).
 #set(ECM_ENABLE_SANITIZERS "leak;address")
-include(ECMEnableSanitizers)
+#include(ECMEnableSanitizers)
 
 # KDE macros.
 # @see https://api.kde.org/ecm/manual/ecm-kde-modules.7.html

--- a/src/AMLMApp.cpp
+++ b/src/AMLMApp.cpp
@@ -28,7 +28,7 @@
 #include <QStandardPaths>
 #include <QUrl>
 
-// KF5
+// KF
 
 // Ours
 #include <utils/TheSimplestThings.h>

--- a/src/AMLMApp.h
+++ b/src/AMLMApp.h
@@ -25,10 +25,10 @@
 // Std C++
 #include <memory>
 
-// Qt5
+// Qt
 #include <QApplication>
 
-// KF5
+// KF
 #include <KConfigGroup>
 #include <QMimeDatabase>
 
@@ -171,7 +171,7 @@ private:
 
     MainWindow* m_the_main_window {nullptr};
 
-	AbstractTreeModel* m_cdb2_model_instance;
+	AbstractTreeModel* m_cdb2_model_instance {nullptr};
 
 //	// Copy of the singleton shared_ptr so we can delete it on the way down.
 //	std::shared_ptr<ScanResultsTreeModel> m_srtm_instance {};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,6 +319,10 @@ target_link_libraries(${PROJECT_NAME}
 		libapp
 )
 
+# Sanitizers.  @todo Make this a CMake option.
+#add_compile_options(-fsanitize=address)
+#target_link_options(${PROJECT_NAME} PRIVATE -static-libasan)
+
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 	COMMAND cloc --no-autogen "--not-match-d=/(third_party|build-|\\.).*/" "--exclude-ext=moc,xml,ui" ${PROJECT_SOURCE_DIR}
 	VERBATIM

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,12 +79,6 @@ get_property(AMLM_LIBCUE_TARGET_SRCS TARGET ${AMLM_LIBCUE_TARGET} PROPERTY SOURC
 set_property(SOURCE ${AMLM_LIBCUE_TARGET_SRCS} PROPERTY SKIP_AUTOGEN ON)
 #message(STATUS "AMLM_LIBCUE_TARGET:SOURCES: ${AMLM_LIBCUE_TARGET_SRCS}")
 
-# Verdigris is just two headers.
-set(USE_BUNDLED_VERDIGRIS 1)
-set(INCLUDE_DIR_VERDIGRIS ${PROJECT_SOURCE_DIR}/src/third_party/verdigris/src)
-add_library(verdigris_target INTERFACE)
-target_include_directories(verdigris_target INTERFACE ${PROJECT_SOURCE_DIR}/src/third_party/verdigris/src)
-
 
 # We make the generated KConfig settings files into their own library so dependencies get handled correctly.
 # The generated files are AwesomeMediaLibraryManagerSettings.cpp and .h.
@@ -112,7 +106,6 @@ set(PROJECT_COMMON_EXTERNAL_LINK_LIB_TARGETS
 		${AMLM_TAGLIB_TARGET}
 		${AMLM_LIBCUE_TARGET}
 #		callable_traits
-		verdigris_target
 #		Boost::thread
 		${Boost_LIBRARIES}
 		)
@@ -163,7 +156,6 @@ set(PROJECT_COMMON_INTERNAL_LINK_LIB_TARGETS
 		logic
 		resources
 		utils
-		${AMLM_WT_LIBRARIES}
         SQLite::SQLite3
 )
 
@@ -198,7 +190,6 @@ target_link_libraries(src
 		gui
 		kconfig_target
 		utils
-		${AMLM_WT_LIBRARIES}
 		SQLite::SQLite3
 	PRIVATE
 		# Boost

--- a/src/Core.h
+++ b/src/Core.h
@@ -46,7 +46,7 @@ class Core : public QObject
 	Q_OBJECT
 
 public:
-	M_GH_DELETE_COPY_AND_MOVE(Core);
+    M_GH_DELETE_COPY_AND_MOVE(Core)
 	~Core() override;
 
 	/**

--- a/src/concurrency/AMLMJob.cpp
+++ b/src/concurrency/AMLMJob.cpp
@@ -58,7 +58,6 @@ AMLMJob::AMLMJob(QObject *parent) : KJob(parent)
     KJobWidgets::setWindow(this, MainWindow::instance());
     setUiDelegate(new KDialogJobUiDelegate());
 
-    connect_or_die(this, &KJob::finished, this, &AMLMJob::SLOT_kjob_finished);
     connect_or_die(this, &KJob::result, this, &AMLMJob::SLOT_kjob_result);
 
     // Master app shutdown signal connection.
@@ -96,37 +95,39 @@ qulonglong AMLMJob::processedSize() const
  *
  * - On normal completion:
  * - Subclass calls emitResult(), which directly calls finishJob(true).
- * -- Shoudn't be any kjob error.
- * -- finishJob(true):
- * -- then d->isFinished = true;
- * -- then the signals are emitted.
- * -- signal finished() is always emitted
- * ++ signal result() is emitted()
- * -- if job is autodelete, deleteLater.
+ *      - Shoudn't be any kjob error.
+ *      - finishJob(true):
+ *      - then d->isFinished = true;
+ *      - then the signals are emitted.
+ *      - signal finished() is always emitted
+ *      - signal result() is emitted()
+ *      - if job is autodelete, deleteLater.
  *
  * - On a KJob::kill():
- * -- the kjob error will first be set to KilledJobError,
- * -- finishJob(emitResult = (verbosity != Quietly)):
- * -- then d->isFinished = true;
- * -- then the signals are emitted:
- * -- signal finished() is always emitted
- * XX signal result() may not be emitted, if this is a kill(quietly).
- * -- if job is autodelete, deleteLater.
+ *      - the kjob error will first be set to KilledJobError,
+ *      - finishJob(emitResult = (verbosity != Quietly)):
+ *      - then d->isFinished = true;
+ *      - then the signals are emitted:
+ *      - signal finished() is always emitted
+ *      - XX signal result() may not be emitted, if this is a kill(quietly).
+ *      - if job is autodelete, deleteLater.
  *
  * - On error:
- * -- Same as normal completion but with an error code?
+ *      - Same as normal completion but with an error code?
  *
  * - On KJob destruction, its destructor does this:
- * -- if(d->isFinished)
- *   {
- *     emit finished(this);
- *   }
- *   delete d_ptr, speedtimer, and uiDelegate.
+ *      - @code
+ *          if(d->isFinished)
+ *          {
+ *              emit finished(this);
+ *          }
+ *          @endcode
+ *      - delete d_ptr, speedtimer, and uiDelegate.
  *
  * - signal finished() is always emitted, and always before result(), which won't be emitted on cancel.
  *
  * - Regarding QObject::deleteLater():
- * -- @link http://doc.qt.io/qt-5/qobject.html#deleteLater
+ *      - @link http://doc.qt.io/qt-5/qobject.html#deleteLater
  *    "if deleteLater() is called on an object that lives in a thread with no running event loop, the object
  *    will be destroyed when the thread finishes."
  *
@@ -172,6 +173,7 @@ qulonglong AMLMJob::processedSize() const
  *
  * ...except they call it with mapReduce().
  */
+
 /// @note Canceling alone won't finish the extfuture, so we finish it manually here.
 /// I think this is the right thing to do.
 ///

--- a/src/concurrency/AMLMJob.h
+++ b/src/concurrency/AMLMJob.h
@@ -25,7 +25,7 @@
 // Std C++
 #include <deque>
 
-// Qt5
+// Qt
 #include <QObject>
 #include <QPointer>
 #include <QWeakPointer>
@@ -35,12 +35,13 @@
 #include <QWaitCondition>
 #include <QSemaphore>
 
-// KF5
+// KF
 #include <KJob>
 #include <KJobUiDelegate>
 
 // Ours
 #include <future/function_traits.hpp>
+#include <future/guideline_helpers.h>
 #include <utils/UniqueIDMixin.h>
 #include "utils/ConnectHelpers.h"
 #include "IExtFutureWatcher.h"
@@ -265,6 +266,7 @@ protected:
 
 public:
     AMLMJob() = delete;
+    M_GH_POLYMORPHIC_SUPPRESS_COPYING_C67(AMLMJob);
     /// Destructor.
     ~AMLMJob() override;
 
@@ -455,8 +457,6 @@ protected Q_SLOTS:
 //    void SLOT_onResultsReadyAt(T ef, int begin, int end);
     /// @}
 
-private:
-    Q_DISABLE_COPY(AMLMJob)
 
 private Q_SLOTS:
 

--- a/src/concurrency/AMLMJobT.h
+++ b/src/concurrency/AMLMJobT.h
@@ -29,7 +29,7 @@
 #include <QPromise>
 #include <QTimer>
 
-// Qt 5 / KDE backfill.
+// Qt / KF backfill.
 #include <utils/QtHelpers.h>
 
 // Ours
@@ -622,14 +622,11 @@ protected:
 
 	bool m_hacky_way_to_ignore_start {false};
 
-    /// The ExtFuture<T>.
+    /// The promise and future.
     /// This is always a copy of an ExtFuture<T> created somewhere outside this class instance.
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-	ExtFutureT m_ext_future { ExtAsync::make_started_only_future<typename ExtFutureT::inner_t>() };
-#else
     ExtPromiseType m_promise;
 	ExtFutureT m_ext_future {};
-#endif
+
 	/// The watcher for the ExtFuture.
 	/// @note Would like to use a std::unique_ptr here, but it screws with the QObject parent/child delete mechanism
 	///       (we get double deletes).

--- a/src/concurrency/tests/AMLMJobTests.cpp
+++ b/src/concurrency/tests/AMLMJobTests.cpp
@@ -200,10 +200,13 @@ const QFuture<void> ImportProjectJob::get_extfuture() const
 
 ////////////////////////
 
-#if 0
+
 
 class TestAMLMJob1;
 using TestAMLMJob1Ptr = QPointer<TestAMLMJob1>;
+
+#if 0
+
 /**
  * Test job derived from AMLMJob.
  */
@@ -277,6 +280,7 @@ protected:
 		AMLMTEST_COUT << "Returning, m_ext_future:" << m_ext_future;
     }
 };
+
 
 #endif
 
@@ -378,7 +382,9 @@ TEST_P(AMLMJobTestsParameterized, DISABLED_SynchronousExecTestAMLMJob1PAutoDelet
 
     TC_EXIT();
 }
+#endif
 
+#if 0
 TEST_P(AMLMJobTestsParameterized, DISABLED_AsynchronousExecTestAMLMJob1PAutoDelete)
 {
     TC_ENTER();
@@ -417,6 +423,9 @@ TEST_P(AMLMJobTestsParameterized, DISABLED_AsynchronousExecTestAMLMJob1PAutoDele
 
     TC_EXIT();
 }
+#endif
+
+#if 0
 
 #if 0 // OBSOLETE
 TEST_F(AMLMJobTests, DISABLED_ThenTest) // NOLINT

--- a/src/concurrency/tests/QTestAMLMJobTests.cpp
+++ b/src/concurrency/tests/QTestAMLMJobTests.cpp
@@ -175,7 +175,7 @@ void tst_QString::DirScanCancelTestPAutodelete()
 	                                    QDir::Files | QDir::AllDirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
 #endif
 	// Run the directory scan in another thread.
-	ExtFuture<DirScanResult> dirresults_future = QtConcurrent::run(DirScanFunction, nullptr,
+	ExtFuture<DirScanResult> dirresults_future = QtConcurrent::run(DirScanFunction,
 																						 dir_url,
 																						 QStringList({"*.flac", "*.mp3", "*.ogg", "*.wav"}),
 																						 QDir::Filters(QDir::Files |

--- a/src/future/InsertionOrderedMap.h
+++ b/src/future/InsertionOrderedMap.h
@@ -305,7 +305,6 @@ Q_DECLARE_ASSOCIATIVE_CONTAINER_METATYPE(InsertionOrderedMap);
 using QVariantInsertionOrderedMap = InsertionOrderedMap<QString, QVariant>;
 // Q_DECLARE_METATYPE_TEMPLATE_2ARG(InsertionOrderedMap);
 Q_DECLARE_METATYPE(QVariantInsertionOrderedMap);
-//Q_DECLARE_ASSOCIATIVE_CONTAINER_METATYPE(InsertionOrderedMap);
 
 
 #endif /* SRC_FUTURE_INSERTIONORDEREDMAP_H_ */

--- a/src/gui/CollectionDockWidget.h
+++ b/src/gui/CollectionDockWidget.h
@@ -68,7 +68,7 @@ private:
 	Q_DISABLE_COPY(CollectionDockWidget)
 
 	QPointer<QStandardItemModel> m_sources_model;
-	QTreeView* m_collection_tree_view;
+    QPointer<QTreeView> m_collection_tree_view;
 
 	QPointer<LibraryModel> modelIndexToLibraryModelPtr(const QModelIndex& modelindex) const;
 

--- a/src/gui/DragDropTreeViewStyleProxy.h
+++ b/src/gui/DragDropTreeViewStyleProxy.h
@@ -38,7 +38,6 @@
  */
 class DragDropTreeViewStyleProxy : public QProxyStyle
 {
-//    W_OBJECT(DragDropTreeViewStyleProxy)
 	Q_OBJECT
 public:
 

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -50,8 +50,9 @@
 
 MDIPlaylistView::MDIPlaylistView(QWidget* parent) : MDITreeViewBase(parent)
 {
-	// Set up a Style Proxy to draw a more natural drop indicator.
-	this->setStyle(new DragDropTreeViewStyleProxy);
+    // Set up a Style Proxy to draw a more natural drop indicator.  setStyle doesn't take ownership of it, so we delete it in the destructor.
+    m_the_dragdropstyleproxy = std::make_unique<DragDropTreeViewStyleProxy>();
+    this->setStyle(m_the_dragdropstyleproxy.get());
 
 	// Give our Window Menu action an icon.
 	m_act_window->setIcon(QIcon::fromTheme("view-media-playlist"));
@@ -106,6 +107,8 @@ MDIPlaylistView::MDIPlaylistView(QWidget* parent) : MDITreeViewBase(parent)
     // Show the user where the item will be dropped.
 	setDropIndicatorShown(true);
 }
+
+MDIPlaylistView::~MDIPlaylistView() = default;
 
 MDIModelViewPair MDIPlaylistView::openModel(QPointer<PlaylistModel> model, QWidget* parent)
 {

--- a/src/gui/MDIPlaylistView.h
+++ b/src/gui/MDIPlaylistView.h
@@ -22,10 +22,12 @@
 
 #include "MDITreeViewBase.h"
 #include <logic/PlaylistModel.h>
+// #include "DragDropTreeViewStyleProxy.h"
 
 class QMediaPlaylist;
 class LibrarySortFilterProxyModel;
 class ItemDelegateLength;
+class DragDropTreeViewStyleProxy;
 
 
 class MDIPlaylistView : public MDITreeViewBase
@@ -43,6 +45,7 @@ Q_SIGNALS:
 
 public:
     explicit MDIPlaylistView(QWidget *parent = Q_NULLPTR);
+    ~MDIPlaylistView() override;
 
 
     /**
@@ -165,6 +168,8 @@ private:
      * @param index
      */
     void startPlaying(const QModelIndex& index);
+
+    std::unique_ptr<DragDropTreeViewStyleProxy> m_the_dragdropstyleproxy;
 
     QPointer<PlaylistModel> m_underlying_model;
     LibrarySortFilterProxyModel* m_sortfilter_model;

--- a/src/gui/MDIPlaylistView.h
+++ b/src/gui/MDIPlaylistView.h
@@ -22,7 +22,6 @@
 
 #include "MDITreeViewBase.h"
 #include <logic/PlaylistModel.h>
-// #include "DragDropTreeViewStyleProxy.h"
 
 class QMediaPlaylist;
 class LibrarySortFilterProxyModel;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -197,6 +197,7 @@ M_WARNING("LOOKS LIKE WE'RE HANGING HERE");
     instance()->m_activity_progress_tracker = nullptr;
 #endif
 
+	Q_CHECK_PTR(m_player);
 	delete m_player;
 
     m_instance = nullptr;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -382,7 +382,7 @@ private:
     QUrl m_appdatadir;
 
     /// The media player instance.
-	MP2* m_player;
+	QPointer<MP2> m_player {};
 
     /// Experimental "scratch" widget for doing development experiments.
     Experimental* m_experimental;

--- a/src/gui/actions/ActionHelpers.h
+++ b/src/gui/actions/ActionHelpers.h
@@ -24,7 +24,7 @@
 
 
 static inline QAction* make_action(const QIcon &icon, const QString &text, QObject *parent = nullptr,
-							QKeySequence shortcut = QKeySequence(), const QString& status_tip = "")
+                                   QKeySequence shortcut = QKeySequence(), const QString& status_tip = QLatin1String(""))
 {
 	QAction* retval = new QAction(icon, text, parent);
 	retval->setShortcut(shortcut);

--- a/src/gui/activityprogressmanager/ActivityProgressPopup.h
+++ b/src/gui/activityprogressmanager/ActivityProgressPopup.h
@@ -20,7 +20,7 @@
 #ifndef SRC_GUI_ACTIVITYPROGRESSMANAGER_ACTIVITYPROGRESSPOPUP_H_
 #define SRC_GUI_ACTIVITYPROGRESSMANAGER_ACTIVITYPROGRESSPOPUP_H_
 
-/// Qt
+// Qt
 #include <QWidget>
 
 /**
@@ -34,8 +34,11 @@
  */
 class ActivityProgressPopup : public QWidget
 {
+    Q_OBJECT
 public:
 	explicit ActivityProgressPopup(QWidget* parent = nullptr);
 };
+
+Q_DECLARE_METATYPE(ActivityProgressPopup)
 
 #endif /* SRC_GUI_ACTIVITYPROGRESSMANAGER_ACTIVITYPROGRESSPOPUP_H_ */

--- a/src/gui/activityprogressmanager/ActivityProgressStatusBarTracker.h
+++ b/src/gui/activityprogressmanager/ActivityProgressStatusBarTracker.h
@@ -22,7 +22,7 @@
 
 #include <config.h>
 
-// Qt5
+// Qt
 class QWidget;
 class QLabel;
 class QToolButton;
@@ -33,7 +33,7 @@ class QProgressBar;
 #include <QSharedPointer>
 #include <QMutex>
 
-// KF5
+// KF
 class KJob;
 #include <KAbstractWidgetJobTracker>
 

--- a/src/gui/activityprogressmanager/CumulativeAMLMJob.h
+++ b/src/gui/activityprogressmanager/CumulativeAMLMJob.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2018, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -26,6 +26,7 @@
 // Ours
 #include <ExtFuture.h>
 #include <concurrency/AMLMJob.h>
+#include <future/guideline_helpers.h>
 #include <utils/TheSimplestThings.h>
 
 class CumulativeAMLMJob;
@@ -46,6 +47,7 @@ class CumulativeAMLMJob : public AMLMJob, public UniqueIDMixin<CumulativeAMLMJob
     using UniqueIDMixin<CumulativeAMLMJob>::uniqueQObjectName;
 
 public:
+    M_GH_POLYMORPHIC_SUPPRESS_COPYING_C67(CumulativeAMLMJob)
 
     using ExtFutureType = ExtFuture<Unit>;
 

--- a/src/gui/activityprogressmanager/CumulativeStatusWidget.h
+++ b/src/gui/activityprogressmanager/CumulativeStatusWidget.h
@@ -54,7 +54,7 @@ public Q_SLOTS:
 private:
 	Q_DISABLE_COPY(CumulativeStatusWidget)
 
-    QToolButton* m_button_show_all_jobs;
+    QToolButton* m_button_show_all_jobs {};
 
     /// @todo Do we need a no-operation-in-progress child widget?
 

--- a/src/gui/menus/HelpMenu.cpp
+++ b/src/gui/menus/HelpMenu.cpp
@@ -28,7 +28,7 @@
 
 #include <utils/ConnectHelpers.h>
 
-HelpMenu::HelpMenu(QWidget* parent, const KAboutData& aboutData, bool showWhatsThis) : KHelpMenu(parent, aboutData, showWhatsThis)
+HelpMenu::HelpMenu(QWidget* parent, const KAboutData& aboutData) : KHelpMenu(parent, aboutData)
 {
 	setObjectName("main_help_menu");
 
@@ -59,7 +59,4 @@ HelpMenu::HelpMenu(QWidget* parent, const KAboutData& aboutData, bool showWhatsT
 
 }
 
-HelpMenu::~HelpMenu()
-{
-
-}
+HelpMenu::~HelpMenu() = default;

--- a/src/gui/menus/HelpMenu.h
+++ b/src/gui/menus/HelpMenu.h
@@ -31,9 +31,8 @@ class HelpMenu : public KHelpMenu
 	using BASE_CLASS = KHelpMenu;
 
 public:
-	explicit HelpMenu(QWidget *parent, const KAboutData &aboutData,
-					  bool showWhatsThis = true);
-	~HelpMenu();
+	explicit HelpMenu(QWidget *parent, const KAboutData &aboutData);
+	~HelpMenu() override;
 };
 
 

--- a/src/gui/widgets/ExperimentalKDEView1.cpp
+++ b/src/gui/widgets/ExperimentalKDEView1.cpp
@@ -28,7 +28,7 @@ bool ExperimentalKDEView1::setModel(AbstractTreeModel* model)
 	remapping << 1;
 	m_column_remapper_proxy->setSourceColumns(remapping);
 
-	M_MESSAGE("I can't get the proxy model or view to work");
+    M_MESSAGE("I can't get the proxy model or view to work")
 	m_cat_proxy_model = QSharedPointer<KCategorizedSortFilterProxyModel>::create(this);
 	m_cat_proxy_model->setSourceModel(m_column_remapper_proxy.get());
 	m_cat_proxy_model->setCategorizedModel(true);

--- a/src/gui/widgets/PlayerControls.cpp
+++ b/src/gui/widgets/PlayerControls.cpp
@@ -113,7 +113,7 @@ PlayerControls::PlayerControls(QWidget *parent) : QWidget(parent)
 	m_volumeSlider = new QSlider(Qt::Horizontal, this);
 	m_volumeSlider->setToolTip(tr("Volume"));
 	m_volumeSlider->setRange(0, 100);
-	// Signal-to-signal connection, emit a changeVolume(int) signal when the user moves the slider.
+	// Signal-to-signal connection, emit a changeVolume(float) signal when the user moves the slider.
 	connect(m_volumeSlider, &QSlider::valueChanged, this, [this](int value)
 		{ Q_EMIT PlayerControls::changeVolume(volume()); });
 

--- a/src/logic/DirScanResult.cpp
+++ b/src/logic/DirScanResult.cpp
@@ -88,7 +88,7 @@ void DirScanResult::fromVariant(const QVariant& variant)
 	set_prefixed_uuid(uuid);
 
 	// Extract all the fields from the map.
-#define X(field_tag, member_field) map_read_field_or_warn(map, field_tag, &member_field);
+#define X(field_tag, member_field) map_read_field_or_warn(map, field_tag, &(member_field));
 	M_DATASTREAM_FIELDS(X);
 #undef X
 }

--- a/src/logic/Library.cpp
+++ b/src/logic/Library.cpp
@@ -202,7 +202,7 @@ void Library::fromVariant(const QVariant& variant)
 	InsertionOrderedMap<QString, QVariant> map;
 	qviomap_from_qvar_or_die(&map, variant);
 
-#define X(field_tag, member_field)   map_read_field_or_warn(map, field_tag, &member_field);
+#define X(field_tag, member_field)   map_read_field_or_warn(map, field_tag, &(member_field));
 	M_DATASTREAM_FIELDS(X);
 #undef X
 

--- a/src/logic/LibraryEntry.cpp
+++ b/src/logic/LibraryEntry.cpp
@@ -293,7 +293,7 @@ using strviw_type = QLatin1String;
 QDebug operator<<(QDebug dbg, const LibraryEntry& obj)
 {
 	QDebugStateSaver saver(dbg);
-#define X(field_tag, member_field) << field_tag << obj.member_field << ","
+#define X(field_tag, member_field) << (field_tag) << obj.member_field << ","
 	dbg M_DATASTREAM_FIELDS(X);
 #undef X
 	return dbg;

--- a/src/logic/LibraryRescanner.cpp
+++ b/src/logic/LibraryRescanner.cpp
@@ -220,7 +220,7 @@ void LibraryRescanner::startAsyncDirectoryTraversal(const QUrl& dir_url)
     auto extensions = SupportedMimeTypes::instance().supportedAudioMimeTypesAsSuffixStringList();
 
 	// Run the directory scan in another thread.
-    QFuture<DirScanResult> dirresults_future = QtConcurrent::run(DirScanFunction, nullptr,
+    QFuture<DirScanResult> dirresults_future = QtConcurrent::run(DirScanFunction,
 	                                                                                     dir_url,
 	                                                                                     extensions,
 	                                                                                     QDir::Filters(QDir::Files |

--- a/src/logic/MP2.cpp
+++ b/src/logic/MP2.cpp
@@ -21,7 +21,6 @@
 #include "MP2.h"
 
 // Qt
-//#include <QMediaPlaylist>
 #include <QDebug>
 #include <QUrlQuery>
 #include <QAudioDevice>

--- a/src/logic/TrackIndex.cpp
+++ b/src/logic/TrackIndex.cpp
@@ -71,7 +71,7 @@ void TrackIndex::fromVariant(const QVariant& variant)
 {
 	InsertionOrderedMap<QString, QVariant> map = variant.value<InsertionOrderedMap<QString, QVariant>>();
 
-#define X(field_tag, field_tag_str, member_field) map_read_field_or_warn(map, field_tag, &member_field);
+#define X(field_tag, field_tag_str, member_field) map_read_field_or_warn(map, field_tag, &(member_field));
 	M_TRACK_INDEX_DATASTREAM_FIELDS(X)
 #undef X
 }

--- a/src/logic/jobs/DirectoryScanJob.cpp
+++ b/src/logic/jobs/DirectoryScanJob.cpp
@@ -32,7 +32,7 @@
 #include <utils/Stopwatch.h>
 
 
-void DirScanFunction(QPromise<DirScanResult>& promise, AMLMJob* /*amlmJob*/,
+void DirScanFunction(QPromise<DirScanResult>& promise,
                      const QUrl& dir_url, // The URL pointing at the directory to recursively scan.
                      const QStringList &name_filters,
 		             const QDir::Filters dir_filters,

--- a/src/logic/jobs/DirectoryScanJob.h
+++ b/src/logic/jobs/DirectoryScanJob.h
@@ -41,13 +41,12 @@
  * Worker function which scans a directory for files.
  *
  * @param promise  The in/out/control ExtFuture.
- * @param amlmJob     The associated AMLMJob, if any.
  * @param dir_url     The URL pointing at the directory to recursively scan.
  * @param name_filters
  * @param dir_filters
  * @param iterator_flags
  */
-void DirScanFunction(QPromise<DirScanResult>& promise, AMLMJob* amlmJob,
+void DirScanFunction(QPromise<DirScanResult>& promise,
                      const QUrl& dir_url,
                      const QStringList &name_filters,
                      const QDir::Filters dir_filters = QDir::NoFilter,

--- a/src/logic/models/AbstractTreeModel.cpp
+++ b/src/logic/models/AbstractTreeModel.cpp
@@ -756,7 +756,7 @@ QModelIndex AbstractTreeModel::index(int row, int column, const QModelIndex &par
 	{
 		return createIndex(row, column, quintptr(child_item->getId()));
 	}
-    else
+	else
 	{
         return QModelIndex();
 	}

--- a/src/logic/models/AbstractTreeModelHeaderItem.cpp
+++ b/src/logic/models/AbstractTreeModelHeaderItem.cpp
@@ -221,7 +221,7 @@ void AbstractTreeModelHeaderItem::fromVariant(const QVariant &variant)
 	/// contains a single <dirscanresult>/QVariantMap.
 	QVariantHomogenousList child_var_list(XMLTAG_CHILD_NODE_LIST, "child");
 	child_var_list = map.at(XMLTAG_CHILD_NODE_LIST).value<QVariantHomogenousList>();
-	Q_ASSERT(child_var_list.size() > 0);
+	Q_ASSERT(!child_var_list.empty());
 	qDb() << "Number of children read:" << child_var_list.size();
 
 #if 1///

--- a/src/logic/proxymodels/SelectionFilterProxyModel.h
+++ b/src/logic/proxymodels/SelectionFilterProxyModel.h
@@ -20,7 +20,7 @@
 #ifndef ENTRYTOMETADATATREEPROXYMODEL_H
 #define ENTRYTOMETADATATREEPROXYMODEL_H
 
-// Qt5
+// Qt
 #include <QSortFilterProxyModel>
 #include <QPersistentModelIndex>
 #include <QPointer>
@@ -47,12 +47,12 @@ Q_SIGNALS:
 
 public:
 	explicit SelectionFilterProxyModel(QObject *parent = Q_NULLPTR);
-	virtual ~SelectionFilterProxyModel();
+	~SelectionFilterProxyModel() override;
     
 	void setSourceModel(QAbstractItemModel* sourceModel) override;
 
 	void setSelectionModel(QItemSelectionModel *selectionModel);
-    QItemSelectionModel *selectionModel() const;
+    QItemSelectionModel* selectionModel() const;
 
 	/**
 	 * Call this to set the one sourceIndex to pass through this proxy.

--- a/src/logic/serialization/ISerializable.cpp
+++ b/src/logic/serialization/ISerializable.cpp
@@ -38,11 +38,10 @@ using std_pair_QString_QVariant = std::pair<const QString, QVariant>;
 Q_DECLARE_METATYPE(std_pair_QString_QVariant);
 
 AMLM_QREG_CALLBACK([](){
-	qIn() << "Registering InsertionOrderedMap<QString, QVariant> alias QVariantInsertionOrderedMap";
+	qIn() << "Registering InsertionOrderedMap<QString, QVariant>";
 	qRegisterMetaType<InsertionOrderedMap<QString, QVariant>>();
 	qRegisterMetaType<std_pair_QString_QVariant>();
 	qRegisterMetaType<SerializableQVariantList>();
-//	AMLMRegisterQFlagQStringConverters<DirScanResult::DirPropFlags>();
 });
 
 

--- a/src/logic/serialization/QVariantHomogenousList.h
+++ b/src/logic/serialization/QVariantHomogenousList.h
@@ -95,7 +95,7 @@ public:
 
 	void clear() noexcept { m_the_list.clear(); }
 
-	void push_back( const QVariant& value ) { m_the_list.push_back(value); };
+    void push_back( const QVariant& value ) { m_the_list.push_back(value); }
 
 	const_iterator cbegin() const noexcept { return std::cbegin(m_the_list); }
 	iterator begin() { return m_the_list.begin(); }

--- a/src/logic/serialization/SerializationHelpers.h
+++ b/src/logic/serialization/SerializationHelpers.h
@@ -143,7 +143,7 @@ template <class ListType, class MemberType,
 void list_push_back_or_die(ListType& list, const MemberType& member)
 {
 	static_assert (!std::is_base_of_v<ISerializable, MemberType>, "DEDUCTION FAILED");
-	qDb() << QMetaType::fromType<MemberType>().name();
+	// qDb() << QMetaType::fromType<MemberType>().name();
 	QVariant qvar = QVariant::fromValue<MemberType>( member );
 	if(!qvar.isValid())
 	{

--- a/src/logic/serialization/XmlSerializer.cpp
+++ b/src/logic/serialization/XmlSerializer.cpp
@@ -28,7 +28,7 @@
 // Std C++ from The Future
 #include <future/overloaded.h>
 
-// Qt5
+// Qt
 #include <QFile>
 #include <QSaveFile>
 #include <QVariant>
@@ -340,7 +340,7 @@ QVariant XmlSerializer::InnerReadVariantFromStream(QString typeString, const QXm
 
 	// Copy the attributes, removing only "type".
 	std::vector<QXmlStreamAttribute> attributes_cp(attributes.cbegin(), attributes.cend());
-	std::experimental::erase_if(attributes_cp, [](auto& attr){ return attr.qualifiedName() == "type" ? true : false; });
+	std::erase_if(attributes_cp, [](auto& attr){ return attr.qualifiedName() == "type" ? true : false; });
 
 	QMetaType metatype = QMetaType::fromName(typeString.toStdString().c_str());
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,6 @@ target_sources(${TEST_EXE_TARGET}
 target_include_directories(${TEST_EXE_TARGET}
                            PRIVATE
                            "utils/nomoc"
-                           ${INCLUDE_DIR_VERDIGRIS}
                            "../src/logic"
                            "../src"
                            # For config.h
@@ -108,7 +107,6 @@ target_compile_definitions(${TEST_EXE_TARGET}
                            # Enable the libstdc++ debug mode.
                            #_GLIBCXX_DEBUG
                            PRIVATE
-                           "USE_BUNDLED_VERDIGRIS=${USE_BUNDLED_VERDIGRIS}"
                            "TEST_FWK_IS_GTEST=1"
 )
 target_compile_definitions(${TEST_EXE_TARGET} PRIVATE "GTEST_LANGUAGE_CXX11")


### PR DESCRIPTION
Removed unneeded connection that was trying to call a slot on the partially deleted AMLMJob from KJob destructor.