### PR TITLE
bugfix/30-post-qt6-loop-and-shuffle-buttons-dont-work

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -49,6 +49,7 @@ set(gui_HEADER_FILES
 	Theme.h
 	delegates/ItemDelegateLength.h
 	delegates/MimeTypeDelegate.h
+	delegates/BoldRowDelegate.h
 	)
 
 # gui source files
@@ -82,6 +83,7 @@ set(gui_SOURCE_FILES
 	Theme.cpp
 	delegates/ItemDelegateLength.cpp
 	delegates/MimeTypeDelegate.cpp
+	delegates/BoldRowDelegate.cpp
 	)
 
 # Settings dialog files (in settings/).

--- a/src/gui/MDILibraryView.cpp
+++ b/src/gui/MDILibraryView.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -88,7 +88,7 @@ QString MDILibraryView::getDisplayName() const
 }
 
 /**
- * Pop up an 'Open file" dialog and open a new View on the file specified by the user.
+ * Pop up an "Open file" dialog and open a new View on the file specified by the user.
  */
 MDIModelViewPair MDILibraryView::open(QWidget *parent, std::function<MDIModelViewPair(QUrl)> find_existing_view_func)
 {

--- a/src/gui/MDINowPlayingView.cpp
+++ b/src/gui/MDINowPlayingView.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -19,15 +19,47 @@
 
 #include "MDINowPlayingView.h"
 
+// Stc C++
+#include <random>
+
+// Ours.
 #include <utils/DebugHelpers.h>
+#include <proxymodels/ShuffleProxyModel.h>
+#include <delegates/BoldRowDelegate.h>
+
+
+
 
 MDINowPlayingView::MDINowPlayingView(QWidget *parent) : MDIPlaylistView(parent)
 {
+	m_brdelegate = new BoldRowDelegate(this);
+    setItemDelegate(m_brdelegate);
+
+    connect(model(), &QAbstractItemModel::modelAboutToBeReset, m_brdelegate, &BoldRowDelegate::clearAll);
+    connect(model(), &QAbstractItemModel::rowsAboutToBeRemoved, this,
+        [](const QModelIndex&, int first, int last)
+		{
+			for (int row = first; row <= last; ++row)
+			{
+				// m_brdelegate->clear_bold_on_this_row();
+			}
+		});
+	connect_or_die(m_brdelegate, &BoldRowDelegate::updateRequested, this, [this]()
+	{
+		this->viewport()->update();
+	});
+
+	// Hook up double-click handler.
+	connect(this, &MDINowPlayingView::doubleClicked, this, &MDINowPlayingView::onDoubleClicked);
+
+	connect_or_die(this, &MDINowPlayingView::activated, this, &MDINowPlayingView::jump);
+
 	// Do not delete this window on close, just hide it.
-M_WARNING("This doesn't seem to work as expected, Collection Widget still segfaults if Now Playing is closed then double-clicked.");
+//This doesn't seem to work as expected, Collection Widget still segfaults if Now Playing is closed then double-clicked.
 //	setAttribute(Qt::WA_DeleteOnClose, false);
 }
 
+// static
 MDINowPlayingView* MDINowPlayingView::openModel(QAbstractItemModel* model, QWidget* parent)
 {
 	auto view = new MDINowPlayingView(parent);
@@ -39,4 +71,160 @@ MDINowPlayingView* MDINowPlayingView::openModel(QAbstractItemModel* model, QWidg
 QString MDINowPlayingView::getDisplayName() const
 {
 	return tr("Now Playing");
+}
+
+void MDINowPlayingView::onNumRowsChanged()
+{
+	// Resize and re-iota-ize the shuffle map.
+	auto num_rows = model()->rowCount();
+	m_indices.resize(num_rows);
+	std::iota(m_indices.begin(), m_indices.end(), 0);
+	if (m_shuffle)
+	{
+		std::ranges::shuffle(m_indices, std::mt19937(std::random_device{}()));
+	}
+}
+
+void MDINowPlayingView::next()
+{
+	QModelIndex current_index = currentIndex();
+	if (!current_index.isValid())
+	{
+		/// @todo Not immediately clear how we recover from this situation.
+		qDb() << "Model's current item is invalid.  Maybe no items in current playlist?";
+		return;
+	}
+
+	m_current_shuffle_index++;
+	if (m_current_shuffle_index >= m_indices.size())
+	{
+		m_current_shuffle_index = 0;
+	}
+
+	auto next_row = m_indices.at(m_current_shuffle_index);
+
+	auto next_index = current_index.sibling(next_row, 0);
+
+    // Set the next index as the current item.
+    const_cast<QAbstractItemModel*>(model())->dataChanged(next_index, next_index, QList<int>(Qt::FontRole));
+    const_cast<QAbstractItemModel*>(model())->dataChanged(current_index, current_index, QList<int>(Qt::FontRole));
+    m_brdelegate->setRow(next_row);
+	setCurrentIndex(next_index);
+	Q_EMIT nowPlayingIndexChanged(next_index, current_index);
+}
+
+void MDINowPlayingView::previous()
+{
+	QModelIndex current_index = currentIndex();
+	if (!current_index.isValid())
+	{
+		/// @todo Not immediately clear how we recover form this situation.
+		qDb() << "Model's current item is invalid.  Maybe no items in current playlist?";
+		return;
+	}
+
+	m_current_shuffle_index--;
+	if (m_current_shuffle_index < 0)
+	{
+		m_current_shuffle_index = m_indices.size() - 1;
+	}
+	auto prev_row = m_indices.at(m_current_shuffle_index);
+
+	auto prev_index = current_index.sibling(prev_row, current_index.column());
+
+    // Set the previous index as the current item.
+    const_cast<QAbstractItemModel*>(model())->dataChanged(prev_index, prev_index, QList<int>(Qt::FontRole));
+    const_cast<QAbstractItemModel*>(model())->dataChanged(current_index, current_index, QList<int>(Qt::FontRole));
+	m_brdelegate->setRow(prev_row);
+	setCurrentIndex(prev_index);
+    Q_EMIT nowPlayingIndexChanged(prev_index, current_index);
+}
+
+void MDINowPlayingView::shuffle(bool shuffle)
+{
+	m_shuffle = shuffle;
+	onNumRowsChanged();
+}
+
+void MDINowPlayingView::jump(const QModelIndex& index)
+{
+	if (index.isValid())
+	{
+		m_brdelegate->setRow(index.row());
+		setCurrentIndex(index);
+		Q_EMIT nowPlayingIndexChanged(index, QModelIndex());
+	}
+}
+
+void MDINowPlayingView::setModel(QAbstractItemModel* model)
+{
+	// Disconnect from the old model.
+	m_disconnector.disconnect();
+
+	// Let the base class set up what it needs to.
+	MDIPlaylistView::setModel(model);
+
+	// Set up signals/slots we need.
+	connectToModel(model);
+}
+
+void MDINowPlayingView::connectToModel(QAbstractItemModel* model)
+{
+	if (model == nullptr)
+	{
+		// Disconnect from the model.
+		m_disconnector.disconnect();
+	}
+	else
+	{
+		m_disconnector
+			<< connect_or_die(model, &QAbstractItemModel::modelReset, this, &MDINowPlayingView::onNumRowsChanged)
+			<< connect_or_die(model, &QAbstractItemModel::rowsInserted, this, &MDINowPlayingView::onNumRowsChanged)
+			<< connect_or_die(model, &QAbstractItemModel::rowsRemoved, this, &MDINowPlayingView::onNumRowsChanged);
+	}
+}
+
+void MDINowPlayingView::onDoubleClicked(const QModelIndex& index)
+{
+	// Should always be valid.
+	qDebug() << "Double-clicked index:" << index;
+	Q_ASSERT(index.isValid());
+
+	M_WARNING("TODO: Fix assumption");
+	if (true) // we're the playlist connected to the player.
+	{
+		startPlaying(index);
+	}
+}
+
+void MDINowPlayingView::onActivated(const QModelIndex& index)
+{
+	M_WARNING("TODO: Fix assumption");
+	if (true) // we're the playlist connected to the player.
+	{
+		startPlaying(index);
+	}
+}
+
+void MDINowPlayingView::startPlaying(const QModelIndex& index)
+{
+	// Tell the player to start playing the song at index.
+	auto underlying_model_index = to_underlying_qmodelindex(index);
+
+	Q_ASSERT(underlying_model_index.isValid());
+
+	qDebug() << "Underlying index:" << underlying_model_index;
+
+	// Since m_underlying_model->qmplaylist() is connected to the player, we should only have to setCurrentIndex() to
+	// start the song.
+	/// @note See "jump()" etc in the Qt5 MediaPlyer example.
+	// Q_ASSERT(underlying_model_index.model() == m_underlying_model);
+    const_cast<QAbstractItemModel*>(model())->dataChanged(index, index, QList<int>(Qt::FontRole));
+    const_cast<QAbstractItemModel*>(model())->dataChanged(index, index, QList<int>(Qt::FontRole));
+    m_brdelegate->setRow(index.row());
+	setCurrentIndex(underlying_model_index);
+
+	// If the player isn't already playing, the index change above won't start it.  Send a signal to it to
+	// make sure it starts.
+	Q_EMIT play();
 }

--- a/src/gui/MDINowPlayingView.h
+++ b/src/gui/MDINowPlayingView.h
@@ -74,6 +74,8 @@ public Q_SLOTS:
 	 */
 	void shuffle(bool shuffle = false);
 
+	void loopAtEnd(bool loop_at_end = false);
+
 	void jump(const QModelIndex& index);
 
 	/// @}
@@ -132,7 +134,6 @@ private:
 	Disconnector m_disconnector;
 
 };
-
 
 
 

--- a/src/gui/MDINowPlayingView.h
+++ b/src/gui/MDINowPlayingView.h
@@ -111,6 +111,8 @@ private:
 	 */
 	void startPlaying(const QModelIndex& index);
 
+	void setCurrentIndexAndRow(const QModelIndex& new_index, const QModelIndex& old_index);
+
 	/**
 	* The map of proxy indices <-> source model indices.
 	*/
@@ -130,6 +132,8 @@ private:
 	Disconnector m_disconnector;
 
 };
+
+
 
 
 #endif //AWESOMEMEDIALIBRARYMANAGER_MDINOWPLAYINGVIEW_H

--- a/src/gui/MDINowPlayingView.h
+++ b/src/gui/MDINowPlayingView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -22,10 +22,23 @@
 
 
 #include "MDIPlaylistView.h"
+#include "delegates/BoldRowDelegate.h"
+
 
 class MDINowPlayingView : public MDIPlaylistView
 {
     Q_OBJECT
+
+Q_SIGNALS:
+	/// @name Signals for player-connected messages.
+	/// @{
+
+	/// Start playing the current song.
+	void play();
+
+	void nowPlayingIndexChanged(const QModelIndex& current, const QModelIndex& previous);
+
+	/// @}
 
 public:
     MDINowPlayingView(QWidget *parent);
@@ -37,7 +50,37 @@ public:
 	
     QString getDisplayName() const override;
 
+	void setModel(QAbstractItemModel* model) override;
+
+public Q_SLOTS:
+
+	void onNumRowsChanged();
+
+	/// @name Slots for player-connected messages.
+	/// @{
+
+	/**
+	 * Start next song.
+	 * Makes the next item in the model the current item in the view.
+	 */
+	void next();
+
+	/// Start previous song.
+	void previous();
+
+	/**
+	 * Shuffles the unshuffled<->shuffled item index map.
+	 * @param shuffle true = shuffle, false = unshuffle.
+	 */
+	void shuffle(bool shuffle = false);
+
+	void jump(const QModelIndex& index);
+
+	/// @}
+
 protected:
+
+	void connectToModel(QAbstractItemModel* model);
 
 	/**
 	 * The Now Playing view isn't directly saveable, but serves as a volatile "scratch" playlist for
@@ -45,9 +88,47 @@ protected:
 	 */
 	bool isModified() const override { return false; }
 
+protected Q_SLOTS:
+
+	/// Invoked when user double-clicks on an entry.
+	/// According to Qt5 docs, index will always be valid:
+	/// http://doc.qt.io/qt-5/qabstractitemview.html#doubleClicked:
+	/// "The [doubleClicked] signal is only emitted when the index is valid."
+	void onDoubleClicked(const QModelIndex& index);
+
+	/**
+	 * Slot called when the user activates (hits Enter) on an item.
+	 * @param index
+	 */
+	void onActivated(const QModelIndex& index) override;
 
 private:
 	Q_DISABLE_COPY(MDINowPlayingView)
+
+	/**
+	 * Tell the player component to start playing the song at @a index.
+	 * @param index
+	 */
+	void startPlaying(const QModelIndex& index);
+
+	/**
+	* The map of proxy indices <-> source model indices.
+	*/
+	std::vector<int> m_indices;
+
+	/// The index into m_indices which should be played.
+	int m_current_shuffle_index {-1};
+
+	/// Current shuffle mode.
+	bool m_shuffle {false};
+
+	/// Current loop mode
+	bool m_loop_at_end {false};
+
+    BoldRowDelegate* m_brdelegate;
+
+	Disconnector m_disconnector;
+
 };
 
 

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -668,7 +668,7 @@ void MDIPlaylistView::startPlaying(const QModelIndex& index)
 
 QModelIndex MDIPlaylistView::to_underlying_qmodelindex(const QModelIndex &proxy_index)
 {
-	auto underlying_model_index = qobject_cast<LibrarySortFilterProxyModel*>(model())->mapToSource(proxy_index);
+	auto underlying_model_index = mapToSourceRecursive(proxy_index);
 	Q_ASSERT(underlying_model_index.isValid());
 
 	return underlying_model_index;
@@ -676,7 +676,7 @@ QModelIndex MDIPlaylistView::to_underlying_qmodelindex(const QModelIndex &proxy_
 
 QModelIndex MDIPlaylistView::from_underlying_qmodelindex(const QModelIndex &underlying_index)
 {
-	auto proxy_model_index = qobject_cast<LibrarySortFilterProxyModel*>(model())->mapFromSource(underlying_index);
+	auto proxy_model_index = mapFromSourceRecursive(model(), underlying_index);
 	return proxy_model_index;
 }
 

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -600,7 +600,6 @@ M_WARNING("TODO: This mostly works, but can start the wrong row if e.g. this vie
 
 void MDIPlaylistView::playlistPositionChanged(qint64 position)
 {
-M_WARNING("CRIT: Do we even need this?")
 	// Notification from the QMediaPlaylist that the current selection has changed.
 	// Since we have a QSortFilterProxyModel between us and the underlying model, we need to convert the position,
 	// which is in underlying-model coordinates, to proxy model coordinates.

--- a/src/gui/MDIPlaylistView.h
+++ b/src/gui/MDIPlaylistView.h
@@ -20,11 +20,13 @@
 #ifndef MDIPLAYLISTVIEW_H
 #define MDIPLAYLISTVIEW_H
 
+
 #include "MDITreeViewBase.h"
 #include <logic/PlaylistModel.h>
 
 class QMediaPlaylist;
 class LibrarySortFilterProxyModel;
+class ShuffleProxyModel;
 class ItemDelegateLength;
 class DragDropTreeViewStyleProxy;
 
@@ -77,6 +79,9 @@ public Q_SLOTS:
 
 	/// Start previous song.
     void previous();
+
+	void onShuffle(bool shuffle);
+
 	/// @}
 
     /// @name Edit slots.
@@ -172,6 +177,7 @@ private:
 
     QPointer<PlaylistModel> m_underlying_model;
     LibrarySortFilterProxyModel* m_sortfilter_model;
+	ShuffleProxyModel* m_shuffle_model;
     ItemDelegateLength* m_length_delegate;
 
 	/// true == shuffle, false == sequential.

--- a/src/gui/MDIPlaylistView.h
+++ b/src/gui/MDIPlaylistView.h
@@ -37,13 +37,6 @@ class MDIPlaylistView : public MDITreeViewBase
 
     using BASE_CLASS = MDITreeViewBase;
 
-Q_SIGNALS:
-	/// @name Signals for player-connected messages.
-	/// @{
-	/// Start playing the current song.
-	void play();
-	/// @}
-
 public:
     explicit MDIPlaylistView(QWidget *parent = Q_NULLPTR);
     ~MDIPlaylistView() override;
@@ -68,19 +61,6 @@ public:
 
 public Q_SLOTS:
 
-	/// @name Slots for player-connected messages.
-	/// @{
-
-	/**
-	 * Start next song.
-	 * Makes the next item in the model the current item in the view.
-	 */
-    void next();
-
-	/// Start previous song.
-    void previous();
-
-	void onShuffle(bool shuffle);
 
 	/// @}
 
@@ -152,32 +132,15 @@ protected Q_SLOTS:
 	void onContextMenuSelectedRows(QContextMenuEvent* event, const QPersistentModelIndexVec& row_indexes) override;
 	void onContextMenuViewport(QContextMenuEvent* event) override;
 
-    /// Invoked when user double-clicks on an entry.
-    /// According to Qt5 docs, index will always be valid:
-    /// http://doc.qt.io/qt-5/qabstractitemview.html#doubleClicked:
-    /// "The [doubleClicked] signal is only emitted when the index is valid."
-    void onDoubleClicked(const QModelIndex &index);
 
-	/**
-	 * Slot called when the user activates (hits Enter) on an item.
-	 * @param index
-	 */
-	void onActivated(const QModelIndex& index) override;
 
 private:
     Q_DISABLE_COPY(MDIPlaylistView)
-
-    /**
-     * Tell the player component to start playing the song at @a index.
-     * @param index
-     */
-    void startPlaying(const QModelIndex& index);
 
     std::unique_ptr<DragDropTreeViewStyleProxy> m_the_dragdropstyleproxy;
 
     QPointer<PlaylistModel> m_underlying_model;
     LibrarySortFilterProxyModel* m_sortfilter_model;
-	ShuffleProxyModel* m_shuffle_model;
     ItemDelegateLength* m_length_delegate;
 
 	/// true == shuffle, false == sequential.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1106,6 +1106,7 @@ void MainWindow::connectPlayerControlsAndPlaylistView(PlayerControls *controls, 
 	/// OR-ed in with any other connection type, which are 0,1,2,3.
     connect_or_die(controls, &PlayerControls::next, playlist_view, &MDIPlaylistView::next, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
     connect_or_die(controls, &PlayerControls::previous, playlist_view, &MDIPlaylistView::previous, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
+	connect_or_die(controls, &PlayerControls::changeShuffle, playlist_view, &MDIPlaylistView::onShuffle);
 
 	// Connect play() signal-to-signal.
     connect_or_die(playlist_view, &MDIPlaylistView::play, controls, &PlayerControls::play, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -573,13 +573,13 @@ void MainWindow::createActions()
 
 //M_WARNING("TODO: Experimental KDE")
 	// Provides a menu entry that allows showing/hiding the toolbar(s)
-//	setStandardToolBarMenuEnabled(true);
+	// setStandardToolBarMenuEnabled(true);
 
 	// Provides a menu entry that allows showing/hiding the statusbar
-//	createStandardStatusBarAction();
+	// createStandardStatusBarAction();
 
 	// Standard 'Configure' menu actions
-//	createSettingsActions();
+	// createSettingsActions();
 /// @end
 }
 
@@ -1075,6 +1075,7 @@ void MainWindow::connectPlayerAndControls(MP2 *player, PlayerControls *controls)
 	connect_or_die(controls, &PlayerControls::changeMuting, player, &MP2::setMuted);
 	connect_or_die(controls, &PlayerControls::changeVolume, player, &MP2::setVolume);
 	connect_or_die(controls, &PlayerControls::changeShuffle, player, &MP2::setShuffleMode);
+    connect_or_die(controls, &PlayerControls::positionSliderMoved, player, &MP2::seek);
 
 	// MP2 -> PlayerControls signals.
     connect_or_die(player, &MP2::playbackStateChanged, controls, &PlayerControls::setPlaybackState);
@@ -1089,27 +1090,25 @@ void MainWindow::connectPlayerAndControls(MP2 *player, PlayerControls *controls)
 	controls->setMuted(player->muted());
 }
 
-void MainWindow::connectPlayerAndPlaylistView(MP2 *player, MDIPlaylistView *playlist_view)
+void MainWindow::connectPlayerAndNowPlayingView(MP2 *player, MDINowPlayingView *now_playing_view)
 {
 	// Connection for the player to tell the playlist to go to the next item when the current one is over.
-	// This in turn will cause a QItemSelectionModel::currentChanged to be emitted, which the player
+	// This in turn will cause a MDINowPlayingView::nowPlayingIndexChanged() to be emitted, which the player
 	// receives and sets up the now-current track.
-	connect_or_die(player, &MP2::playlistToNext, playlist_view, &MDIPlaylistView::next);
-
-	auto selection_model = playlist_view->selectionModel();
-	connect_or_die(selection_model, &QItemSelectionModel::currentChanged, player, &MP2::onPlaylistPositionChanged);
+	connect_or_die(player, &MP2::playlistToNext, now_playing_view, &MDINowPlayingView::next);
+	connect_or_die(now_playing_view, &MDINowPlayingView::nowPlayingIndexChanged, player, &MP2::onPlaylistPositionChanged);
 }
 
-void MainWindow::connectPlayerControlsAndPlaylistView(PlayerControls *controls, MDIPlaylistView *playlist_view)
+void MainWindow::connectPlayerControlsAndNowPlayingView(PlayerControls *controls, MDINowPlayingView* now_playing_view)
 {
 	/// @note Qt::ConnectionType() cast here is due to the mixed flag/enum nature of the type.  Qt::UniqueConnection (0x80) can be bitwise-
 	/// OR-ed in with any other connection type, which are 0,1,2,3.
-    connect_or_die(controls, &PlayerControls::next, playlist_view, &MDIPlaylistView::next, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
-    connect_or_die(controls, &PlayerControls::previous, playlist_view, &MDIPlaylistView::previous, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
-	connect_or_die(controls, &PlayerControls::changeShuffle, playlist_view, &MDIPlaylistView::onShuffle);
+    connect_or_die(controls, &PlayerControls::next, now_playing_view, &MDINowPlayingView::next, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
+    connect_or_die(controls, &PlayerControls::previous, now_playing_view, &MDINowPlayingView::previous, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
+	connect_or_die(controls, &PlayerControls::changeShuffle, now_playing_view, &MDINowPlayingView::shuffle);
 
 	// Connect play() signal-to-signal.
-    connect_or_die(playlist_view, &MDIPlaylistView::play, controls, &PlayerControls::play, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
+    connect_or_die(now_playing_view, &MDINowPlayingView::play, controls, &PlayerControls::play, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
 }
 
 void MainWindow::connectLibraryViewAndMainWindow(MDILibraryView *lv)
@@ -1135,8 +1134,8 @@ void MainWindow::connectNowPlayingViewAndMainWindow(MDINowPlayingView* now_playi
 	connect_or_die(this, &MainWindow::settingsChanged, now_playing_view, &MDILibraryView::onSettingsChanged);
 
 
-	connectPlayerAndPlaylistView(m_player, now_playing_view);
-	connectPlayerControlsAndPlaylistView(m_controls, now_playing_view);
+	connectPlayerAndNowPlayingView(m_player, now_playing_view);
+	connectPlayerControlsAndNowPlayingView(m_controls, now_playing_view);
     qDebug() << "Connected";
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1071,11 +1071,14 @@ void MainWindow::connectPlayerAndControls(MP2 *player, PlayerControls *controls)
 	connect_or_die(controls, &PlayerControls::play, player, &MP2::play);
 	connect_or_die(controls, &PlayerControls::pause, player, &MP2::pause);
 	connect_or_die(controls, &PlayerControls::stop, player, &MP2::stop);
+	/// See connectPlayerControlsAndNowPlayingView(), this might not actually do anything.
 	connect_or_die(controls, &PlayerControls::changeRepeat, player, &MP2::repeat);
 	connect_or_die(controls, &PlayerControls::changeMuting, player, &MP2::setMuted);
 	connect_or_die(controls, &PlayerControls::changeVolume, player, &MP2::setVolume);
 	connect_or_die(controls, &PlayerControls::changeShuffle, player, &MP2::setShuffleMode);
     connect_or_die(controls, &PlayerControls::positionSliderMoved, player, &MP2::seek);
+	connect_or_die(controls, &PlayerControls::posSliderPressed, player, &MP2::seekStart);
+	connect_or_die(controls, &PlayerControls::posSliderReleased, player, &MP2::seekEnd);
 
 	// MP2 -> PlayerControls signals.
     connect_or_die(player, &MP2::playbackStateChanged, controls, &PlayerControls::setPlaybackState);
@@ -1106,6 +1109,7 @@ void MainWindow::connectPlayerControlsAndNowPlayingView(PlayerControls *controls
     connect_or_die(controls, &PlayerControls::next, now_playing_view, &MDINowPlayingView::next, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
     connect_or_die(controls, &PlayerControls::previous, now_playing_view, &MDINowPlayingView::previous, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
 	connect_or_die(controls, &PlayerControls::changeShuffle, now_playing_view, &MDINowPlayingView::shuffle);
+	connect_or_die(controls, &PlayerControls::changeRepeat, now_playing_view, &MDINowPlayingView::loopAtEnd);
 
 	// Connect play() signal-to-signal.
     connect_or_die(now_playing_view, &MDINowPlayingView::play, controls, &PlayerControls::play, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -312,9 +312,9 @@ private:
 
 	/// @name Bulk Signal/Slot Connection management.
     ///@{
-    void connectPlayerAndControls(MP2 *m_player, PlayerControls *m_controls);
-    void connectPlayerAndPlaylistView(MP2 *m_player, MDIPlaylistView *playlist_view);
-    void connectPlayerControlsAndPlaylistView(PlayerControls *controls, MDIPlaylistView *playlist_view);
+    void connectPlayerAndControls(MP2 *m_player, PlayerControls* m_controls);
+    void connectPlayerAndNowPlayingView(MP2 *m_player, MDINowPlayingView* playlist_view);
+    void connectPlayerControlsAndNowPlayingView(PlayerControls *controls, MDINowPlayingView* now_playing_view);
 
     void connectLibraryViewAndMainWindow(MDILibraryView* lv);
 	void connectPlaylistViewAndMainWindow(MDIPlaylistView* plv);

--- a/src/gui/delegates/BoldRowDelegate.cpp
+++ b/src/gui/delegates/BoldRowDelegate.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of AwesomeMediaLibraryManager.
+ *
+ * AwesomeMediaLibraryManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AwesomeMediaLibraryManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "BoldRowDelegate.h"
+
+#include <QStyledItemDelegate>
+
+
+BoldRowDelegate::BoldRowDelegate(QObject* parent) : QStyledItemDelegate(parent)
+{
+}
+
+BoldRowDelegate::~BoldRowDelegate() = default;
+
+void BoldRowDelegate::setRow(ssize_t row)
+{
+    m_row = row;
+	// Track which rows have been bolded.
+	m_bolded_rows.insert(row);
+    clearAllButOne();
+}
+
+void BoldRowDelegate::clearAll()
+{
+	if (!m_bolded_rows.empty())
+	{
+		m_bolded_rows.clear();
+		Q_EMIT updateRequested();
+	}
+}
+
+void BoldRowDelegate::clearAllButOne()
+{
+    if (!m_bolded_rows.empty())
+    {
+        m_bolded_rows.clear();
+        m_bolded_rows.insert(m_row);
+        Q_EMIT updateRequested();
+    }
+}
+
+void BoldRowDelegate::initStyleOption(QStyleOptionViewItem* option, const QModelIndex& index) const
+{
+	QStyledItemDelegate::initStyleOption(option, index);
+
+	// Make m_row bold.
+	if (index.row() == m_row)
+	{
+		option->font.setBold(true);
+	}
+}

--- a/src/gui/delegates/BoldRowDelegate.h
+++ b/src/gui/delegates/BoldRowDelegate.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of AwesomeMediaLibraryManager.
+ *
+ * AwesomeMediaLibraryManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AwesomeMediaLibraryManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BOLDROWDELEGATE_H
+#define BOLDROWDELEGATE_H
+
+// Std C++
+#include <set>
+
+// Qt
+#include <QStyledItemDelegate>
+
+
+/**
+ * Delegate which sets a given row's font to bold.
+ */
+class BoldRowDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit BoldRowDelegate(QObject* parent = nullptr);
+	~BoldRowDelegate() override;
+
+
+
+    void setRow(ssize_t row);
+
+    void clearAll();
+    void clearAllButOne();
+
+protected:
+
+	void initStyleOption(QStyleOptionViewItem *option,
+						 const QModelIndex &index) const override;
+
+Q_SIGNALS:
+    void updateRequested();
+
+private:
+    ssize_t m_row {-1};
+
+    std::set<int> m_bolded_rows;
+};
+
+Q_DECLARE_METATYPE(BoldRowDelegate)
+
+#endif //BOLDROWDELEGATE_H

--- a/src/gui/widgets/PlayerControls.cpp
+++ b/src/gui/widgets/PlayerControls.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -19,6 +19,7 @@
 
 #include "PlayerControls.h"
 
+// Qt
 #include <QToolButton>
 #include <QStyle>
 #include <QSlider>
@@ -32,6 +33,7 @@
 #include <qxtglobalshortcut.h>
 #endif
 
+// Ours
 #include <gui/Theme.h>
 #include "utils/ConnectHelpers.h"
 #include <gui/actions/ActionHelpers.h>
@@ -107,8 +109,10 @@ PlayerControls::PlayerControls(QWidget *parent) : QWidget(parent)
     //slider->sliderMoved.connect(seek)
 	// Signal to signal connection.
 	connect(m_positionSlider, &QSlider::sliderMoved, this, &PlayerControls::positionSliderMoved);
+	connect_or_die(m_positionSlider, &QSlider::sliderPressed, this, &PlayerControls::posSliderPressed);
+	connect_or_die(m_positionSlider, &QSlider::sliderReleased, this, &PlayerControls::posSliderReleased);
 
-    // Time Remaining/Duration label.
+	// Time Remaining/Duration label.
 	m_labelDuration = new QLabel(this);
 
     // Volume slider.
@@ -336,6 +340,7 @@ void PlayerControls::updateDurationInfo(qint64 pos, qint64 duration)
 		duration = m_last_dur;
     }
 
+	// For display, use seconds granularity.
     pos /= 1000;
     duration /= 1000;
 

--- a/src/gui/widgets/PlayerControls.cpp
+++ b/src/gui/widgets/PlayerControls.cpp
@@ -103,8 +103,10 @@ PlayerControls::PlayerControls(QWidget *parent) : QWidget(parent)
 
     // Position slider
 	m_positionSlider = new QSlider(Qt::Horizontal, this);
-    //slider->setRange(0, player.duration() / 1000)
+    // m_positionSlider->setRange(0, player.duration());
     //slider->sliderMoved.connect(seek)
+	// Signal to signal connection.
+	connect(m_positionSlider, &QSlider::sliderMoved, this, &PlayerControls::positionSliderMoved);
 
     // Time Remaining/Duration label.
 	m_labelDuration = new QLabel(this);
@@ -315,7 +317,10 @@ void PlayerControls::onPositionChanged(qint64 pos)
 {
     // Position is in ms.
 	m_last_pos = pos;
-	m_positionSlider->setValue(pos);
+	if (!m_positionSlider->isSliderDown())
+	{
+		m_positionSlider->setValue(pos);
+	}
     updateDurationInfo(pos, -1);
 }
 

--- a/src/gui/widgets/PlayerControls.h
+++ b/src/gui/widgets/PlayerControls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -19,6 +19,8 @@
 
 #ifndef PLAYERCONTROLS_H
 #define PLAYERCONTROLS_H
+
+// @file
 
 #include <QWidget>
 #include <QMediaPlayer>
@@ -57,6 +59,8 @@ Q_SIGNALS:
 	void changeVolume(float);
     void changeMuting(bool);
 	void positionSliderMoved(int);
+	void posSliderPressed();
+	void posSliderReleased();
 
 public Q_SLOTS:
     void setPlaybackState(QMediaPlayer::PlaybackState state);

--- a/src/gui/widgets/PlayerControls.h
+++ b/src/gui/widgets/PlayerControls.h
@@ -56,6 +56,7 @@ Q_SIGNALS:
 	void changeRepeat(bool);
 	void changeVolume(float);
     void changeMuting(bool);
+	void positionSliderMoved(int);
 
 public Q_SLOTS:
     void setPlaybackState(QMediaPlayer::PlaybackState state);

--- a/src/logic/AMLMTrack.cpp
+++ b/src/logic/AMLMTrack.cpp
@@ -20,7 +20,7 @@
 /**
  * @file AMLMTrack.cpp
  */
-#include <AMLMTrack.h>
+#include "AMLMTrack.h"
 
 namespace AMLM
 {

--- a/src/logic/AudioFileType.h
+++ b/src/logic/AudioFileType.h
@@ -20,7 +20,11 @@
 #ifndef AWESOMEMEDIALIBRARYMANAGER_AUDIOFILETYPE_H
 #define AWESOMEMEDIALIBRARYMANAGER_AUDIOFILETYPE_H
 
-// Qt5
+/**
+ * @file AudioFileType
+ */
+
+// Qt
 #include <QMetaType>
 #include <QObject>
 

--- a/src/logic/CueSheet.h
+++ b/src/logic/CueSheet.h
@@ -17,23 +17,27 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file CueSheet
+ */
+
 #ifndef SRC_LOGIC_CUESHEET_H_
 #define SRC_LOGIC_CUESHEET_H_
 
 #include <config.h>
 
-/// Std C++
+// Std C++
 #include <vector>
 #include <memory>
 #include <cstdint>
 #include <map>
 #include <mutex>
 
-/// Qt5
+// Qt
 class QUrl;
 #include <QDataStream>
 
-/// Ours
+// Ours
 #include "TrackMetadata.h"  ///< Per-track cue sheet info
 #include <future/guideline_helpers.h>
 #include "CueSheetParser.h"

--- a/src/logic/DirScanResult.h
+++ b/src/logic/DirScanResult.h
@@ -20,12 +20,14 @@
 #ifndef SRC_LOGIC_DIRSCANRESULT_H_
 #define SRC_LOGIC_DIRSCANRESULT_H_
 
+/// @file DirScanResult.h
+
 #include <config.h>
 
 // Std C++
 #include <optional>
 
-// Qt5
+// Qt
 #include <QUrl>
 #include <QFileInfo>
 #include <QDateTime>

--- a/src/logic/ExtMimeType.h
+++ b/src/logic/ExtMimeType.h
@@ -20,6 +20,11 @@
 #ifndef EXTMIMETYPE_H
 #define EXTMIMETYPE_H
 
+/**
+ * @file ExtMimeType
+ */
+
+// Qt
 #include <QObject>
 #include <QMimeDatabase>
 #include <QMimeType>

--- a/src/logic/LibraryRescanner.cpp
+++ b/src/logic/LibraryRescanner.cpp
@@ -221,12 +221,12 @@ void LibraryRescanner::startAsyncDirectoryTraversal(const QUrl& dir_url)
 
     // Set up the directory scan to run in another thread.
     QFuture<DirScanResult> dirresults_future = QtConcurrent::run(DirScanFunction,
-	                                                                                     dir_url,
-	                                                                                     extensions,
-	                                                                                     QDir::Filters(QDir::Files |
-	                                                                                                   QDir::AllDirs |
-	                                                                                                   QDir::NoDotAndDotDot),
-	                                                                                     QDirIterator::Subdirectories);
+                                                                     dir_url,
+                                                                     extensions,
+                                                                     QDir::Filters(QDir::Files |
+                                                                                   QDir::AllDirs |
+                                                                                   QDir::NoDotAndDotDot),
+                                                                     QDirIterator::Subdirectories);
 	// Create/Attach an AMLMJobT to the dirscan future.
 	QPointer<AMLMJobT<ExtFuture<DirScanResult>>> dirtrav_job = make_async_AMLMJobT(dirresults_future, "DirResultsJob", AMLMApp::instance());
 

--- a/src/logic/MP2.cpp
+++ b/src/logic/MP2.cpp
@@ -17,6 +17,7 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/// @file
 
 #include "MP2.h"
 

--- a/src/logic/MP2.cpp
+++ b/src/logic/MP2.cpp
@@ -166,6 +166,12 @@ void MP2::repeat(bool loop)
 	m_loop_setting = loop ? MP2::Loop : MP2::NoLoop;
 }
 
+void MP2::seek(int msecs)
+{
+    qDb() << "Seek pct: " << (msecs/duration()) << "msecs:" << msecs << M_ID_VAL(duration());
+	setPosition(msecs);
+}
+
 void MP2::onPositionChanged(qint64 pos)
 {
 	if(m_is_subtrack)
@@ -194,14 +200,13 @@ void MP2::onPositionChanged(qint64 pos)
 void MP2::onDurationChanged(qint64 duration)
 {
 	qDebug() << QString("onDurationChanged: %1").arg(duration);
-	if(m_is_subtrack)
+
+    if(m_is_subtrack)
 	{
-		Q_EMIT durationChanged2(m_track_endpos_ms - m_track_startpos_ms);
+        duration = m_track_endpos_ms - m_track_startpos_ms;
 	}
-	else
-	{
-		Q_EMIT durationChanged2(duration);
-	}
+
+    Q_EMIT durationChanged2(duration);
 }
 
 void MP2::onMediaStatusChanged(QMediaPlayer::MediaStatus status)
@@ -271,7 +276,7 @@ void MP2::onSourceChanged(const QUrl& media_url)
 
 void MP2::onPlaylistPositionChanged(const QModelIndex& current, const QModelIndex& previous)
 {
-	// We get in here when the Playlist view sends the QItemSelectionModel::currentChanged signal.
+	// We get in here when the Now Playing view sends the MDINowPlayingView::nowPlayingIndexChanged signal.
 	// That signal can come from:
 	// - User input on the playlist view.
 	// - The MP2::playlistToNext signal emitted by us (in two different places).
@@ -279,7 +284,7 @@ void MP2::onPlaylistPositionChanged(const QModelIndex& current, const QModelInde
 	m_onPositionChanged_sending_playlistToNext = false;
 	m_EndOfMedia_sending_playlistToNext = false;
 
-	qDb() << "playlistPosChanged:" << current;
+	qDb() << "playlistPosChanged:" << current.row();
 
 	if (!current.isValid())
 	{

--- a/src/logic/MP2.h
+++ b/src/logic/MP2.h
@@ -20,6 +20,8 @@
 #ifndef MP2_H
 #define MP2_H
 
+/// @file
+
 #include <QAction>
 #include <QMediaPlayer>
 #include <QAudioOutput>

--- a/src/logic/MP2.h
+++ b/src/logic/MP2.h
@@ -31,9 +31,6 @@ class MP2 : public QMediaPlayer
 {
 	Q_OBJECT
 
-	Q_PROPERTY(bool muted READ muted WRITE setMuted NOTIFY mutedChanged)
-	Q_PROPERTY(float volume READ volume WRITE setVolume NOTIFY volumeChanged)
-
 public:
 	enum ShuffleSetting {Shuffle, Sequential};
 	Q_ENUM(ShuffleSetting)
@@ -51,7 +48,11 @@ public:
 	float volume() const;
 
 Q_SIGNALS:
+	/// This signal is emitted from the QMediaPlayer::positionChanged()-absorbing slot onPositionChanged()
+	/// with an argument that is normalized to 0, that is, relative to the start of the track.
 	void positionChanged2(qint64);
+	/// This signal is emitted from the QMediaPlayer::durationChanged()-absorbing slot onDurationChanged()
+	/// with an argument that is normalized to 0, that is, relative to the start of the track.
 	void durationChanged2(qint64);
 	void mutedChanged(bool);
 	void volumeChanged(float);
@@ -61,6 +62,9 @@ Q_SIGNALS:
 
 private:
 	Q_DISABLE_COPY(MP2)
+
+	void createActions();
+	void getTrackInfoFromUrl(QUrl url);
 
 	std::unique_ptr<QAudioOutput> m_audio_output;
 
@@ -74,14 +78,14 @@ private:
 	ShuffleSetting m_shuffle_setting {Shuffle};
 	LoopSetting m_loop_setting {Loop};
 	bool m_playing { false };
+	bool m_seeking { false };
 
 	/// We need to keep track of who gets to the end-of-(sub)track first, so we can block the other one
 	/// from emitting the same playlistToNext signal.
 	bool m_EndOfMedia_sending_playlistToNext {false};
 	bool m_onPositionChanged_sending_playlistToNext {false};
 
-	void createActions();
-	void getTrackInfoFromUrl(QUrl url);
+
 
 public Q_SLOTS:
 	void play();
@@ -91,11 +95,16 @@ public Q_SLOTS:
 	void setShuffleMode(bool shuffle_on);
 	void repeat(bool loop);
 	void seek(int msecs);
+	void seekStart();
+	void seekEnd();
 
+	void onPlaylistPositionChanged(const QModelIndex& current, const QModelIndex& previous);
+
+private Q_SLOTS:
 	void onPositionChanged(qint64 pos);
 	void onDurationChanged(qint64 duration);
 	void onMediaStatusChanged(QMediaPlayer::MediaStatus status);
-	void onPlaylistPositionChanged(const QModelIndex& current, const QModelIndex& previous);
+	void onPlaybackStateChanged(QMediaPlayer::PlaybackState newState);
 	void onSourceChanged(const QUrl& media_url);
 	void onErrorOccurred(QMediaPlayer::Error error, const QString& errorString);
 };

--- a/src/logic/MP2.h
+++ b/src/logic/MP2.h
@@ -40,7 +40,7 @@ public:
 	Q_ENUM(LoopSetting)
 
 public:
-	explicit MP2(QObject *parent = Q_NULLPTR);
+	explicit MP2(QObject *parent = nullptr);
 
 	/// Property overrides.
 	qint64 position() const;
@@ -88,6 +88,7 @@ public Q_SLOTS:
     void setVolume(float volume);
 	void setShuffleMode(bool shuffle_on);
 	void repeat(bool loop);
+	void seek(int msecs);
 
 	void onPositionChanged(qint64 pos);
 	void onDurationChanged(qint64 duration);

--- a/src/logic/PlaylistModel.h
+++ b/src/logic/PlaylistModel.h
@@ -97,6 +97,7 @@ protected:
 
 };
 
+Q_DECLARE_METATYPE(PlaylistModel)
 Q_DECLARE_METATYPE(const PlaylistModel*)
 Q_DECLARE_METATYPE(std::shared_ptr<PlaylistModel>)
 

--- a/src/logic/models/AbstractTreeModelItem.cpp
+++ b/src/logic/models/AbstractTreeModelItem.cpp
@@ -80,7 +80,6 @@ AbstractTreeModelItem::AbstractTreeModelItem(const std::vector<QVariant>& data, 
 
 AbstractTreeModelItem::~AbstractTreeModelItem()
 {
-    qDb() << "DELETING";
 	deregister_self();
 }
 

--- a/src/logic/models/AbstractTreeModelItem.h
+++ b/src/logic/models/AbstractTreeModelItem.h
@@ -32,7 +32,7 @@
 #include <mutex>
 #include <iterator>
 
-// Qt5
+// Qt
 #include <QList>
 #include <QVariant>
 #include <QVector>
@@ -47,6 +47,7 @@
 #include <logic/serialization/ISerializable.h>
 #include <logic/serialization/SerializationHelpers.h>
 #include "UndoRedoHelper.h"
+
 class AbstractTreeModel;
 
 /**

--- a/src/logic/models/ScanResultsTreeModelItem.cpp
+++ b/src/logic/models/ScanResultsTreeModelItem.cpp
@@ -58,7 +58,6 @@ ScanResultsTreeModelItem::ScanResultsTreeModelItem(const QVariant& variant, cons
 
 ScanResultsTreeModelItem::~ScanResultsTreeModelItem()
 {
-    qDb() << "DELETING";
 }
 
 QVariant ScanResultsTreeModelItem::data(int column, int role) const

--- a/src/logic/ntp.cpp
+++ b/src/logic/ntp.cpp
@@ -17,10 +17,14 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file Implementation of ntp, a Normal Play Time support class for QUrl. */
+/**
+ * @file ntp.cpp
+ * Implementation of ntp, a Normal Play Time support class for QUrl.
+ */
 
 #include "ntp.h"
 
+// Qt
 #include <QRegularExpression>
 #include <QUrl>
 #include <QUrlQuery>

--- a/src/logic/ntp.h
+++ b/src/logic/ntp.h
@@ -17,11 +17,15 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file Interface for ntp, a Normal Play Time support class for QUrl. */
+/**
+ * @file ntp.h
+ * Interface for ntp, a Normal Play Time support class for QUrl.
+ */
 
 #ifndef NTP_H
 #define NTP_H
 
+// Std C++
 #include <string>
 
 

--- a/src/logic/proxymodels/CMakeLists.txt
+++ b/src/logic/proxymodels/CMakeLists.txt
@@ -24,6 +24,7 @@ set(proxymodels_subdir_SOURCES
 	LibrarySortFilterProxyModel.cpp
 	ModelChangeWatcher.cpp
 	QPersistentModelIndexVec.cpp
+	ShuffleProxyModel.cpp
 )
 
 set(proxymodels_subdir_HEADERS
@@ -32,6 +33,7 @@ set(proxymodels_subdir_HEADERS
     LibrarySortFilterProxyModel.h
     ModelChangeWatcher.h
     QPersistentModelIndexVec.h
+	ShuffleProxyModel.h
 )
 
 add_library(proxymodels STATIC EXCLUDE_FROM_ALL)

--- a/src/logic/proxymodels/CMakeLists.txt
+++ b/src/logic/proxymodels/CMakeLists.txt
@@ -21,6 +21,7 @@
 
 set(proxymodels_subdir_SOURCES
 	SelectionFilterProxyModel.cpp
+	ModelHelpers.cpp
 	LibrarySortFilterProxyModel.cpp
 	ModelChangeWatcher.cpp
 	QPersistentModelIndexVec.cpp

--- a/src/logic/proxymodels/LibrarySortFilterProxyModel.h
+++ b/src/logic/proxymodels/LibrarySortFilterProxyModel.h
@@ -20,7 +20,14 @@
 #ifndef LIBRARYSORTFILTERPROXYMODEL_H
 #define LIBRARYSORTFILTERPROXYMODEL_H
 
+/**
+ * @file
+ */
+
+// Std C++
 #include <memory>
+
+// Qt
 #include <QSortFilterProxyModel>
 
 class LibraryEntry;

--- a/src/logic/proxymodels/ModelChangeWatcher.h
+++ b/src/logic/proxymodels/ModelChangeWatcher.h
@@ -20,10 +20,16 @@
 #ifndef MODELCHANGEWATCHER_H
 #define MODELCHANGEWATCHER_H
 
+/**
+ * @file
+ */
+
+// Qt
 #include <QObject>
 #include <QPointer>
 
 class QAbstractItemModel;
+
 
 
 class ModelChangeWatcher : public QObject

--- a/src/logic/proxymodels/ModelHelpers.cpp
+++ b/src/logic/proxymodels/ModelHelpers.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of AwesomeMediaLibraryManager.
+ *
+ * AwesomeMediaLibraryManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AwesomeMediaLibraryManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
+ */
+

--- a/src/logic/proxymodels/ModelHelpers.h
+++ b/src/logic/proxymodels/ModelHelpers.h
@@ -20,12 +20,18 @@
 #ifndef MODELHELPERS_H
 #define MODELHELPERS_H
 
+/**
+ * @file
+ */
+
+// Qt
 #include <QPersistentModelIndex>
 #include <QModelIndexList>
 #include <QItemSelection>
 #include <QAbstractProxyModel>
 #include <QDebug>
 
+// Ours
 #include <utils/DebugHelpers.h>
 #include <logic/proxymodels/QPersistentModelIndexVec.h>
 

--- a/src/logic/proxymodels/ModelHelpers.h
+++ b/src/logic/proxymodels/ModelHelpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -83,20 +83,29 @@ inline static QPersistentModelIndexVec pindexes(const QItemSelection& selection,
 	}
 }
 
-inline static QModelIndex mapToSource(const QModelIndex& proxy_index)
-{
-	if(proxy_index.model())
-	{
-		// There's a model.  See if it's a proxy model.
-		auto proxy_model = qobject_cast<const QAbstractProxyModel*>(proxy_index.model());
-		if(proxy_model)
-		{
-			return proxy_model->mapToSource(proxy_index);
-		}
-	}
+/**
+ * Maps a proxy QModelIndex through all intermediate proxies and returns the model's corresponding QModelIndex.
+ * @param proxy_index The QModelIndex to an item in the proxy.
+ * @return The QModelIndex in the bottom-most model corresponding to the @a proxy_index.
+ */
+QModelIndex mapToSourceRecursive(const QModelIndex& proxy_index);
 
-	return proxy_index;
-}
+/**
+ * Applies mapToSourceRecursive(const QModelIndex&) to each index in @a source_indices.
+ * @see mapToSourceRecursive(const QModelIndex&)
+ * @param source_indices The list of QModelIndex's to map to source.
+ * @return The mapped list.
+ */
+QModelIndexList mapToSourceRecursive(const QModelIndexList& source_indices);
+
+/**
+ * 
+ * @param proxy_index
+ * @param top_proxy
+ * @return
+ */
+QModelIndex mapFromSourceRecursive(const QAbstractItemModel* top_proxy, const QModelIndex& source_model_index);
+
 
 template <template<class> class T>
 T<QPersistentModelIndex> mapQPersistentModelIndexesToSource(const T<QPersistentModelIndex>& iterable_of_pindexes)
@@ -104,23 +113,16 @@ T<QPersistentModelIndex> mapQPersistentModelIndexesToSource(const T<QPersistentM
 	T<QPersistentModelIndex> retval;
 	for(auto i : iterable_of_pindexes)
 	{
-		retval.push_back(mapToSource(i));
+        retval.push_back(mapToSourceRecursive(i));
 	}
 	return retval;
 }
 
-inline static QModelIndexList mapToSource(const QModelIndexList& source_indices)
-{
-	QModelIndexList retval;
-
-	for(auto i : source_indices)
-	{
-		retval.push_back(mapToSource(i));
-	}
-
-	return retval;
-}
-
+/**
+ * @warning I'm not sure this is correct.
+ * @param maybe_proxy_model
+ * @return
+ */
 inline static QAbstractItemModel* getRootModel(QAbstractItemModel* maybe_proxy_model)
 {
 	auto proxy_model = qobject_cast<QAbstractProxyModel*>(maybe_proxy_model);

--- a/src/logic/proxymodels/ShuffleProxyModel.cpp
+++ b/src/logic/proxymodels/ShuffleProxyModel.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of AwesomeMediaLibraryManager.
+ *
+ * AwesomeMediaLibraryManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AwesomeMediaLibraryManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ShuffleProxyModel.h"
+
+// Std C++
+#include <numeric>
+#include <algorithm>
+#include <random>
+
+
+void ShuffleProxyModel::shuffle(bool shuffle)
+{
+	beginResetModel();
+	m_indices.resize(sourceModel()->rowCount());
+	std::iota(m_indices.begin(), m_indices.end(), 0);
+	if (shuffle)
+	{
+		std::ranges::shuffle(m_indices, std::mt19937(std::random_device{}()));
+	}
+	endResetModel();
+}
+
+QModelIndex ShuffleProxyModel::mapFromSource(const QModelIndex& sourceIndex) const
+{
+	if (!sourceIndex.isValid())
+    {
+        return {};
+    }
+	return createIndex(m_indices[sourceIndex.row()], sourceIndex.column());
+}
+
+QModelIndex ShuffleProxyModel::mapToSource(const QModelIndex &proxyIndex) const
+{
+	if (!proxyIndex.isValid())
+	{
+		return {};
+	}
+
+	return sourceModel()->index(m_indices[proxyIndex.row()], proxyIndex.column());
+}

--- a/src/logic/proxymodels/ShuffleProxyModel.h
+++ b/src/logic/proxymodels/ShuffleProxyModel.h
@@ -20,6 +20,10 @@
 #ifndef SHUFFLEPROXYMODEL_H
 #define SHUFFLEPROXYMODEL_H
 
+/**
+ * @file
+ */
+
 // Std C++
 #include <vector>
 
@@ -40,6 +44,12 @@ class ShuffleProxyModel : public QSortFilterProxyModel
 public:
 	explicit ShuffleProxyModel(QObject* parent = nullptr);
     ~ShuffleProxyModel() noexcept override = default;
+
+	/**
+	 * 
+	 * @param shuffle_model_rows true == shuffle model rows, false == shuffle navigation order.
+	 */
+	void shuffleModelRows(bool shuffle_model_rows);
 
 	/**
 	 * Shuffles the proxy<->source model map.
@@ -67,6 +77,15 @@ protected:
 
 private:
 	/**
+	 * Sets whether shuffling is on or off.
+	 */
+	bool m_shuffle {false};
+
+	bool m_shuffle_model_rows {false};
+
+	int m_current_row {0};
+
+	/**
 	* The map of proxy indices <-> source model indices.
 	*/
 	std::vector<int> m_indices;
@@ -74,6 +93,7 @@ private:
 	Disconnector m_disconnector;
 };
 
-
+// For queued-connection support (i.e. thread-safe slots)
+Q_DECLARE_METATYPE(ShuffleProxyModel)
 
 #endif //SHUFFLEPROXYMODEL_H

--- a/src/logic/proxymodels/ShuffleProxyModel.h
+++ b/src/logic/proxymodels/ShuffleProxyModel.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *
@@ -24,6 +24,7 @@
 #include <vector>
 
 // Qt
+#include <ConnectHelpers.h>
 #include <QSortFilterProxyModel>
 #include <QModelIndex>
 
@@ -34,25 +35,43 @@
 */
 class ShuffleProxyModel : public QSortFilterProxyModel
 {
+    Q_OBJECT
+
 public:
-	explicit ShuffleProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
-    ~ShuffleProxyModel() = default;
+	explicit ShuffleProxyModel(QObject* parent = nullptr);
+    ~ShuffleProxyModel() noexcept override = default;
 
 	/**
 	 * Shuffles the proxy<->source model map.
 	 * @param shuffle true = shuffle, false = unshuffle.
 	 */
-	void shuffle(bool shuffle);
+    void shuffle(bool shuffle = false);
 
 	QModelIndex mapFromSource(const QModelIndex& sourceIndex) const override;
 
     QModelIndex mapToSource(const QModelIndex &proxyIndex) const override;
+
+	void setSourceModel(QAbstractItemModel* sourceModel) override;
+
+public Q_SLOTS:
+
+    void onNumRowsChanged();
+
+protected:
+	/**
+	 * Connect the necessary signals and slots between this proxy model
+	 * and the (proxy) model it's attached to.  Pass nullptr to disconnect any existing connections.
+	 * @param model The model to connect to.  Pass nullptr to disconnect.
+	 */
+	void connectToModel(QAbstractItemModel *model);
 
 private:
 	/**
 	* The map of proxy indices <-> source model indices.
 	*/
 	std::vector<int> m_indices;
+
+	Disconnector m_disconnector;
 };
 
 

--- a/src/logic/proxymodels/ShuffleProxyModel.h
+++ b/src/logic/proxymodels/ShuffleProxyModel.h
@@ -1,0 +1,60 @@
+/*
+* Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of AwesomeMediaLibraryManager.
+ *
+ * AwesomeMediaLibraryManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AwesomeMediaLibraryManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SHUFFLEPROXYMODEL_H
+#define SHUFFLEPROXYMODEL_H
+
+// Std C++
+#include <vector>
+
+// Qt
+#include <QSortFilterProxyModel>
+#include <QModelIndex>
+
+
+/**
+* A proxy model which shuffles the rows of the source model.
+* The source model is not altered.
+*/
+class ShuffleProxyModel : public QSortFilterProxyModel
+{
+public:
+	explicit ShuffleProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
+    ~ShuffleProxyModel() = default;
+
+	/**
+	 * Shuffles the proxy<->source model map.
+	 * @param shuffle true = shuffle, false = unshuffle.
+	 */
+	void shuffle(bool shuffle);
+
+	QModelIndex mapFromSource(const QModelIndex& sourceIndex) const override;
+
+    QModelIndex mapToSource(const QModelIndex &proxyIndex) const override;
+
+private:
+	/**
+	* The map of proxy indices <-> source model indices.
+	*/
+	std::vector<int> m_indices;
+};
+
+
+
+#endif //SHUFFLEPROXYMODEL_H

--- a/src/logic/serialization/XmlSerializer.cpp
+++ b/src/logic/serialization/XmlSerializer.cpp
@@ -342,8 +342,6 @@ QVariant XmlSerializer::InnerReadVariantFromStream(QString typeString, const QXm
 	}
 	else if(metatype.id() == f_serqvarlist_id)
 	{
-#warning "Remove"
-		log_current_node(xmlstream); qDb() << "serqvarlist";
 		variant = readHomogenousListFromStream(xmlstream);
 	}
 	else

--- a/src/logic/serialization/XmlSerializer.cpp
+++ b/src/logic/serialization/XmlSerializer.cpp
@@ -297,14 +297,6 @@ void XmlSerializer::writeVariantValueToStream(const QVariant &variant, QXmlStrea
 
 
 
-/**
- * XmlSerializer::readVariantFromStream
- *
- * @note On invalid QVariant, skips the current element and tries to continue.
- *
- * @param xmlstream
- * @return
- */
 QVariant XmlSerializer::readVariantFromStream(QXmlStreamReader& xmlstream)
 {
 	QXmlStreamAttributes attributes = xmlstream.attributes();

--- a/src/logic/serialization/XmlSerializer.h
+++ b/src/logic/serialization/XmlSerializer.h
@@ -98,7 +98,15 @@ private:
 	/// @name Read members
 	/// @{
 
-	QVariant readVariantFromStream(QXmlStreamReader& xmlstream);
+    /**
+	 * XmlSerializer::readVariantFromStream
+	 *
+	 * @note On invalid QVariant, skips the current element and tries to continue.
+	 *
+	 * @param xmlstream
+	 * @return
+	 */
+    QVariant readVariantFromStream(QXmlStreamReader& xmlstream);
 
 	QVariant InnerReadVariantFromStream(QString typeString, const QXmlStreamAttributes& attributes, QXmlStreamReader& xmlstream);
 	QVariant readHomogenousListFromStream(QXmlStreamReader& xmlstream);

--- a/src/utils/AboutDataSetup.cpp
+++ b/src/utils/AboutDataSetup.cpp
@@ -17,6 +17,8 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/// @file
+
 #include "AboutDataSetup.h"
 
 #include <KAboutData>

--- a/src/utils/AboutDataSetup.h
+++ b/src/utils/AboutDataSetup.h
@@ -20,7 +20,9 @@
 #ifndef AWESOMEMEDIALIBRARYMANAGER_ABOUTDATASETUP_H
 #define AWESOMEMEDIALIBRARYMANAGER_ABOUTDATASETUP_H
 
+/// @file
 
+// Qt
 #include <KAboutData>
 
 class AboutDataSetup

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -40,6 +40,7 @@ set(utils_HEADER_FILES
 	ext_iterators.h
 )
 set(utils_SOURCE_FILES
+	ConnectHelpers.cpp
 	DebugBlock.cpp
 	DebugHelpers.cpp
 	ext_iterators.cpp

--- a/src/utils/ConnectHelpers.cpp
+++ b/src/utils/ConnectHelpers.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of AwesomeMediaLibraryManager.
+ *
+ * AwesomeMediaLibraryManager is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AwesomeMediaLibraryManager is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ConnectHelpers.h"
+
+// Qt
+#include <QObject>
+#include <QMetaObject>
+
+
+Disconnector::Disconnector()
+{
+}
+
+Disconnector::~Disconnector()
+{
+}
+
+void Disconnector::addConnection(QMetaObject::Connection connection)
+{
+	m_connections.push_back(connection);
+}
+
+Disconnector& Disconnector::operator<<(QMetaObject::Connection connection)
+{
+	addConnection(connection);
+    return *this;
+}
+
+void Disconnector::disconnect()
+{
+	for(auto& connection : m_connections)
+    {
+    	bool status = QObject::disconnect(connection);
+        Q_ASSERT(status == true);
+        m_connections.clear();
+    }
+}

--- a/src/utils/ConnectHelpers.cpp
+++ b/src/utils/ConnectHelpers.cpp
@@ -17,6 +17,8 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/// @file ConnectHelpers.cpp
+
 #include "ConnectHelpers.h"
 
 // Qt

--- a/src/utils/ConnectHelpers.h
+++ b/src/utils/ConnectHelpers.h
@@ -20,6 +20,8 @@
 #ifndef CONNECTHELPERS_H
 #define CONNECTHELPERS_H
 
+/// @file ConnectHelpers.h
+
 // Std C++
 #include <vector>
 

--- a/src/utils/DebugHelpers.h
+++ b/src/utils/DebugHelpers.h
@@ -20,6 +20,8 @@
 #ifndef DEBUGHELPERS_H
 #define DEBUGHELPERS_H
 
+/// @file
+
 #include <config.h>
 
 // Std C++

--- a/src/utils/StringHelpers.h
+++ b/src/utils/StringHelpers.h
@@ -20,6 +20,8 @@
 #ifndef STRINGHELPERS_H
 #define STRINGHELPERS_H
 
+/// @file StringHelpers.h
+
 #include <config.h>
 
 // Std C
@@ -29,7 +31,7 @@
 #include <type_traits>
 #include <string>
 
-// Qt5
+// Qt
 #include <QtGlobal>
 #include <QString>
 #include <QStringList>


### PR DESCRIPTION
- Shuffle and loop now working
- Seek working
- Duration fixed for subtracks
- New class Disconnector, to allow easy disconnection of any number of signal-slot connections
- Some Doxygen work