### PR TITLE
bugfix/64-now-playings-nextprev-disappears-after-clicking-in-unpopulated-area

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,9 +218,9 @@ if(UNIX)
 	target_compile_options(cxx_compile_options
 		INTERFACE
 			-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-		-fno-eliminate-unused-debug-types -fno-inline)
+		-fno-eliminate-unused-debug-types -fno-inline -fmodules)
 	ucm_add_flags(-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-		-fno-eliminate-unused-debug-types -fno-inline)
+		-fno-eliminate-unused-debug-types -fno-inline -fmodules)
 # Flags for GNU libstdc++
 ### @todo Detect that we're actually using GNU libstdc++
 # "compiles user code using the debug mode. When defined, _GLIBCXX_ASSERTIONS is defined automatically"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,9 +218,9 @@ if(UNIX)
 	target_compile_options(cxx_compile_options
 		INTERFACE
 			-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-		-fno-eliminate-unused-debug-types)
+		-fno-eliminate-unused-debug-types -fno-inline)
 	ucm_add_flags(-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-		-fno-eliminate-unused-debug-types)
+		-fno-eliminate-unused-debug-types -fno-inline)
 # Flags for GNU libstdc++
 ### @todo Detect that we're actually using GNU libstdc++
 # "compiles user code using the debug mode. When defined, _GLIBCXX_ASSERTIONS is defined automatically"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,7 +226,8 @@ target_compile_definitions(libapp
                            PRIVATE
 	                           # libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
 	                           # Enable the libstdc++ debug mode.
-	                           #_GLIBCXX_DEBUG
+	                           _GLIBCXX_DEBUG
+								-D_GLIBCXX_DEBUG_BACKTRACE
 	                           "KXMLGUI_NO_DEPRECATED=1"
 )
 target_include_directories(libapp
@@ -264,7 +265,8 @@ target_compile_definitions(${PROJECT_NAME}
 	PUBLIC
 		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
 		# Enable the libstdc++ debug mode.
-		#_GLIBCXX_DEBUG
+		_GLIBCXX_DEBUG
+		_GLIBCXX_DEBUG_BACKTRACE
 		"KXMLGUI_NO_DEPRECATED=1"
 	)
 target_include_directories(${PROJECT_NAME}
@@ -288,6 +290,7 @@ target_link_libraries(${PROJECT_NAME}
 		cxx_definitions_qt
 	PRIVATE
 		libapp
+		stdc++exp # For debug backtrace in the std lib.
 )
 
 # Sanitizers.  @todo Make this a CMake option.

--- a/src/gui/MDILibraryView.cpp
+++ b/src/gui/MDILibraryView.cpp
@@ -390,11 +390,6 @@ void MDILibraryView::onContextMenuViewport(QContextMenuEvent* event)
 	context_menu->exec(event->globalPos());
 }
 
-/**
- * Slot called when the user activates (hits Enter or double-clicks) on an item or items.
- * In the Library view, activating items appends the items to the "Now Playing" playlist
- * and then starts playing the first one.
- */
 void MDILibraryView::onActivated(const QModelIndex& index)
 {
 	// Should always be valid.
@@ -416,7 +411,7 @@ void MDILibraryView::onActivated(const QModelIndex& index)
 
 	// Send the tracks to the "Now Playing" playlist, by way of MainWindow.
 	LibraryEntryMimeData* mime_data = selectedRowsToMimeData(selected_row_pindexes);
-	mime_data->m_drop_target_instructions = { DropTargetInstructions::IDAE_APPEND, DropTargetInstructions::PA_START_PLAYING };
+	mime_data->m_drop_target_instructions = { DropTargetInstructions::IDAE_APPEND, DropTargetInstructions::PA_NONE };
 	Q_EMIT sendToNowPlaying(mime_data);
 }
 

--- a/src/gui/MDILibraryView.cpp
+++ b/src/gui/MDILibraryView.cpp
@@ -70,7 +70,7 @@ MDILibraryView::MDILibraryView(QWidget* parent) : MDITreeViewBase(parent)
 	setSelectionMode(QAbstractItemView::ExtendedSelection);
 
 	// Hook up double-click handler.
-	connect(this, &MDILibraryView::doubleClicked, this, &MDILibraryView::onDoubleClicked);
+	connect_or_die(this, &MDILibraryView::doubleClicked, this, &MDILibraryView::onDoubleClicked);
 
 	// Configure drag and drop.
 	//// Libraries can't have items dragged around inside them.
@@ -133,8 +133,8 @@ MDIModelViewPair MDILibraryView::openFile(QUrl open_url, QWidget *parent, std::f
 	{
 		Q_ASSERT_X(mv_pair.m_model_was_existing, "openFile", "find_exisiting returned a model but said it was not pre-existing.");
 
-        qDebug() << "Model exists:" << mv_pair.m_model_stack.data();
-		libmodel = qobject_cast<LibraryModel*>(mv_pair.m_model_stack);
+        qDebug() << "Model exists:" << mv_pair.getTopModel().data();
+		libmodel = qobject_cast<LibraryModel*>(mv_pair.getRootModel());
 	}
 	else
 	{
@@ -155,7 +155,7 @@ MDIModelViewPair MDILibraryView::openFile(QUrl open_url, QWidget *parent, std::f
 		/// @note Need this cast due to some screwyness I mean subtleties of C++'s member access control rules.
 		/// In very shortened form: Derived member functions can only access "protected" members through
 		/// an object of the Derived type, not of the Base type.
-		qobject_cast<MDILibraryView*>(mvpair.m_view)->setCurrentFile(open_url);
+        qobject_cast<MDILibraryView*>(mvpair.getView())->setCurrentFile(open_url);
 		return mvpair;
     }
     else

--- a/src/gui/MDILibraryView.cpp
+++ b/src/gui/MDILibraryView.cpp
@@ -50,6 +50,10 @@
 
 MDILibraryView::MDILibraryView(QWidget* parent) : MDITreeViewBase(parent)
 {
+	static int id = 0;
+	std::string name = std::format("MDILibraryView{}", id);
+	++id;
+	setObjectName(name);
 	// Not sure what's going on here, but if I don't set this to something here, the tabs stay "(Untitled)".
 	/// @todo Seems like we no longer need to do this.
 //	setWindowTitle("DUMMY");
@@ -186,9 +190,11 @@ MDIModelViewPair MDILibraryView::openModel(QPointer<LibraryModel> model, QWidget
 
 void MDILibraryView::setModel(QAbstractItemModel* model)
 {
-	// Keep a ref to the real model.
+	// Keep refs to the {proxy}models.
     m_sortfilter_model = qobject_cast<LibrarySortFilterProxyModel*>(model);
+	Q_CHECK_PTR(m_sortfilter_model);
     m_underlying_model = qobject_cast<LibraryModel*>(m_sortfilter_model->sourceModel());
+	Q_CHECK_PTR(m_underlying_model);
 
 	// Set our "current file" to the root dir of the model.
 	setCurrentFile(m_underlying_model->getLibRootDir());

--- a/src/gui/MDILibraryView.h
+++ b/src/gui/MDILibraryView.h
@@ -95,7 +95,7 @@ public:
 protected:
 	QPointer<LibraryModel> m_underlying_model;
 
-	// LibrarySortFilterProxyModel* m_sortfilter_model;
+	LibrarySortFilterProxyModel* m_sortfilter_model;
 
 	ItemDelegateLength* m_length_delegate;
 	MimeTypeDelegate* m_mimetype_delegate;

--- a/src/gui/MDILibraryView.h
+++ b/src/gui/MDILibraryView.h
@@ -90,13 +90,12 @@ public:
 
 	LibraryModel* underlyingModel() const override;
 
-	LibrarySortFilterProxyModel* proxy_model() const { return m_sortfilter_model; }
-
+	LibrarySortFilterProxyModel* proxy_model() const;
 
 protected:
 	QPointer<LibraryModel> m_underlying_model;
 
-	LibrarySortFilterProxyModel* m_sortfilter_model;
+	// LibrarySortFilterProxyModel* m_sortfilter_model;
 
 	ItemDelegateLength* m_length_delegate;
 	MimeTypeDelegate* m_mimetype_delegate;

--- a/src/gui/MDILibraryView.h
+++ b/src/gui/MDILibraryView.h
@@ -137,9 +137,9 @@ protected Q_SLOTS:
 	void onContextMenuViewport(QContextMenuEvent* event) override;
 
 	/**
-	 * Slot called when the user activates (hits Enter or double-clicks) on an item.
-	 * In the Library view, activating an item sends that item to the "Now Playing" playlist
-	 * which then starts playing it.
+	 * Slot called when the user activates (hits Enter or double-clicks) on an item or items.
+	 * In the Library view, activating items appends the items to the "Now Playing" playlist
+	 * and then starts playing the first one.
 	 */
 	void onActivated(const QModelIndex& index) override;
 

--- a/src/gui/MDILibraryView.h
+++ b/src/gui/MDILibraryView.h
@@ -94,20 +94,17 @@ public:
 
 protected:
 	QPointer<LibraryModel> m_underlying_model;
-
 	LibrarySortFilterProxyModel* m_sortfilter_model;
-
 	ItemDelegateLength* m_length_delegate;
 	MimeTypeDelegate* m_mimetype_delegate;
 
 	///
 	/// Pure virtual function overrides.
 	///
-
     void setEmptyModel() override;
 
-	virtual QString getNewFilenameTemplate() const override;
-	virtual QString defaultNameFilter() override;
+	QString getNewFilenameTemplate() const override;
+	QString defaultNameFilter() override;
 
 	/// @name Serialization
 	/// @{
@@ -115,12 +112,12 @@ protected:
 	/**
 	 * Called by openFile().
 	 */
-    virtual bool readFile(QUrl load_url) override;
+	bool readFile(QUrl load_url) override;
 
 	///@todo Override writeFile?
 
-	virtual void serializeDocument(QFileDevice& file) override;
-	virtual void deserializeDocument(QFileDevice& file) override;
+	void serializeDocument(QFileDevice& file) override;
+	void deserializeDocument(QFileDevice& file) override;
 
 	/// @}
 

--- a/src/gui/MDINowPlayingView.cpp
+++ b/src/gui/MDINowPlayingView.cpp
@@ -66,135 +66,6 @@ QString MDINowPlayingView::getDisplayName() const
 	return tr("Now Playing");
 }
 
-#if 0
-void MDINowPlayingView::onNumRowsChanged()
-{
-	// Resize and re-iota-ize the shuffle map.
-	auto num_rows = model()->rowCount();
-
-	// Maintain our shuffle index.
-	if (num_rows == 0)
-	{
-		m_current_shuffle_index = -1;
-	}
-	bool was_empty = (m_current_shuffle_index == -1) ? true : false;
-    ssize_t temp_shuffle_index = -1;
-	if (m_current_shuffle_index >= 0 && m_current_shuffle_index < m_indices.size())
-	{
-		temp_shuffle_index = m_indices.at(m_current_shuffle_index);
-	}
-	
-	m_indices.resize(num_rows);
-	std::iota(m_indices.begin(), m_indices.end(), 0);
-
-	if (m_shuffle)
-	{
-		std::ranges::shuffle(m_indices, std::mt19937(std::random_device{}()));
-	}
-
-	m_current_shuffle_index = temp_shuffle_index;
-	if (was_empty && model()->rowCount() > 0)
-	{
-		// Went from empty Now Playing to non-empty.  Set a current item and selected item,
-		// so that the play button works.
-		// QTimer stuff here because this is segfaulting:
-		// selectionModel()->select(model()->index(0, 0),
-		//           QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-		QTimer::singleShot(0, [this](){
-			m_current_shuffle_index = m_indices.at(0);
-			setCurrentIndexAndRow(model()->index(0, 0), QModelIndex());
-		});
-	}
-}
-#endif
-
-#if 0
-void MDINowPlayingView::next()
-{
-	QModelIndex current_index = currentIndex();
-	if (!current_index.isValid())
-	{
-		/// @todo Not immediately clear how we recover from this situation.
-		qDb() << "Model's current item is invalid.  Maybe no items in current playlist?";
-		return;
-	}
-
-	bool stop_playing {false};
-
-	m_current_shuffle_index++;
-	if (m_current_shuffle_index >= m_indices.size())
-	{
-		m_current_shuffle_index = 0;
-		if (!m_loop_at_end)
-		{
-			stop_playing = true;
-		}
-	}
-
-	// Map from sequential m_current_shuffle_index [0, 1, ..., n) to possibly shuffled song index.
-	auto next_row = m_indices.at(m_current_shuffle_index);
-
-	auto next_index = current_index.sibling(next_row, 0);
-
-	// Set the next index as the current item.
-	/// @todo Not sure if the Q_EMITs here need to be non-queued or not.
-	Q_EMIT const_cast<QAbstractItemModel*>(model())->dataChanged(next_index, next_index, QList<int>(Qt::FontRole));
-	Q_EMIT const_cast<QAbstractItemModel*>(model())->dataChanged(current_index, current_index, QList<int>(Qt::FontRole));
-	if (stop_playing)
-	{
-		next_index = QModelIndex();
-	}
-	setCurrentIndexAndRow(next_index, current_index);
-}
-
-void MDINowPlayingView::previous()
-{
-	QModelIndex current_index = currentIndex();
-	if (!current_index.isValid())
-	{
-		/// @todo Not immediately clear how we recover form this situation.
-		qDb() << "Model's current item is invalid.  Maybe no items in current playlist?";
-		return;
-	}
-
-	m_current_shuffle_index--;
-	if (m_current_shuffle_index < 0)
-	{
-		m_current_shuffle_index = m_indices.size() - 1;
-	}
-	auto prev_row = m_indices.at(m_current_shuffle_index);
-
-	auto prev_index = current_index.sibling(prev_row, current_index.column());
-
-    // Set the previous index as the current item.
-	/// @todo Not sure if the Q_EMITs here need to be non-queued or not.
-    Q_EMIT const_cast<QAbstractItemModel*>(model())->dataChanged(prev_index, prev_index, QList<int>(Qt::FontRole));
-    Q_EMIT const_cast<QAbstractItemModel*>(model())->dataChanged(current_index, current_index, QList<int>(Qt::FontRole));
-	setCurrentIndexAndRow(prev_index, current_index);
-}
-
-void MDINowPlayingView::shuffle(bool shuffle)
-{
-	m_shuffle = shuffle;
-	onNumRowsChanged();
-}
-
-// void MDINowPlayingView::setLoopAtEnd(bool loop_at_end)
-// {
-// 	m_loop_at_end = loop_at_end;
-// }
-
-void MDINowPlayingView::jump(const QModelIndex& index)
-{
-	if (index.isValid())
-	{
-		// old_index might be QModelIndex() here.
-		auto old_index = currentIndex();
-		setCurrentIndexAndRow(index, old_index);
-	}
-}
-#endif
-
 void MDINowPlayingView::setModel(QAbstractItemModel* model)
 {
 	// Disconnect from the old model.
@@ -237,9 +108,6 @@ void MDINowPlayingView::onDoubleClicked(const QModelIndex& index)
 	// M_WARNING("TODO: Fix assumption");
 	if (true) // we're the playlist connected to the player.
 	{
-		// Keep the shuffle index synced.
-		// m_current_shuffle_index = m_indices[index.row()];
-#warning "TODO"
 		startPlaying(index);
 	}
 }
@@ -249,10 +117,6 @@ void MDINowPlayingView::onActivated(const QModelIndex& index)
     // M_WARNING("TODO: Fix assumption");
 	if (true) // we're the playlist connected to the player.
 	{
-		// Keep the shuffle index synced.
-#warning "TODO"
-		// m_current_shuffle_index = m_indices[index.row()];
-
 		startPlaying(index);
 	}
 }

--- a/src/gui/MDINowPlayingView.h
+++ b/src/gui/MDINowPlayingView.h
@@ -52,34 +52,7 @@ public:
 
 public Q_SLOTS:
 
-	// void onNumRowsChanged();
-
-	/// @name Slots for player-connected messages.
-	/// @{
-#if 0
-	/**
-	 * Start next song.
-	 * Makes the next item in the model the current item in the view.
-	 */
-	void next();
-
-	/// Start previous song.
-	void previous();
-
-	/**
-	 * Shuffles the unshuffled<->shuffled item index map.
-	 * @param shuffle true = shuffle, false = unshuffle.
-	 */
-	void shuffle(bool shuffle = false);
-
-	// void loopAtEnd(bool loop_at_end = false);
-
-	void jump(const QModelIndex& index);
-#endif
-
     void setCurrentIndexAndRow(const QModelIndex& new_index, const QModelIndex& old_index);
-
-	/// @}
 
 protected:
 
@@ -113,24 +86,6 @@ private:
 	 * @param index
 	 */
 	void startPlaying(const QModelIndex& index);
-
-
-#if 0
-
-	/**
-	* The map of proxy indices <-> source model indices.
-	*/
-	std::vector<int> m_indices;
-
-	/// The index into m_indices which should be played.
-	int m_current_shuffle_index {-1};
-
-	/// Current shuffle mode.
-	bool m_shuffle {false};
-
-	/// Current loop mode
-	bool m_loop_at_end {false};
-#endif
 
     QPointer<BoldRowDelegate> m_brdelegate;
 

--- a/src/gui/MDINowPlayingView.h
+++ b/src/gui/MDINowPlayingView.h
@@ -66,7 +66,7 @@ protected:
 
 protected Q_SLOTS:
 
-	/// Invoked when user double-clicks on an entry.
+	/// Invoked when the user double-clicks on an entry.
 	/// According to Qt docs, index will always be valid:
 	/// https://doc.qt.io/qt-6/qabstractitemview.html#doubleClicked:
 	/// "The [doubleClicked] signal is only emitted when the index is valid."

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -64,9 +64,9 @@ MDIPlaylistView::MDIPlaylistView(QWidget* parent) : MDITreeViewBase(parent)
 	m_underlying_model = nullptr;
 
 	// The sort and Filter proxy model.
-//	 m_sortfilter_model = new LibrarySortFilterProxyModel(this);
-	// m_sortfilter_model->setDynamicSortFilter(false);
-	// m_sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
+	 m_sortfilter_model = new LibrarySortFilterProxyModel(this);
+	 m_sortfilter_model->setDynamicSortFilter(false);
+	 m_sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
 
 	// Delegates.
 	m_length_delegate = new ItemDelegateLength(this);

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -64,9 +64,9 @@ MDIPlaylistView::MDIPlaylistView(QWidget* parent) : MDITreeViewBase(parent)
 	m_underlying_model = nullptr;
 
 	// The sort and Filter proxy model.
-	m_sortfilter_model = new LibrarySortFilterProxyModel(this);
-	m_sortfilter_model->setDynamicSortFilter(false);
-	m_sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
+//	 m_sortfilter_model = new LibrarySortFilterProxyModel(this);
+	// m_sortfilter_model->setDynamicSortFilter(false);
+	// m_sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
 
 	// Delegates.
 	m_length_delegate = new ItemDelegateLength(this);
@@ -116,10 +116,10 @@ MDIPlaylistView::~MDIPlaylistView() = default;
 MDIModelViewPair MDIPlaylistView::openModel(QPointer<PlaylistModel> model, QWidget* parent)
 {
 	MDIModelViewPair retval;
-	retval.setModel(model);
+	retval.appendModel(model);
 
-	retval.m_view = new MDIPlaylistView(parent);
-	qobject_cast<MDIPlaylistView*>(retval.m_view)->setModel(model);
+	retval.appendView(new MDIPlaylistView(parent));
+    // qobject_cast<MDIPlaylistView*>(retval.m_view)->setModel(model);
 
 	return retval;
 }

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -64,9 +64,9 @@ MDIPlaylistView::MDIPlaylistView(QWidget* parent) : MDITreeViewBase(parent)
 	m_underlying_model = nullptr;
 
 	// The sort and Filter proxy model.
-	 m_sortfilter_model = new LibrarySortFilterProxyModel(this);
-	 m_sortfilter_model->setDynamicSortFilter(false);
-	 m_sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
+	m_sortfilter_model = new LibrarySortFilterProxyModel(this);
+	m_sortfilter_model->setDynamicSortFilter(false);
+	m_sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
 
 	// Delegates.
 	m_length_delegate = new ItemDelegateLength(this);
@@ -118,66 +118,68 @@ MDIModelViewPair MDIPlaylistView::openModel(QPointer<PlaylistModel> model, QWidg
 	MDIModelViewPair retval;
 	retval.appendModel(model);
 
+	// The sort and Filter proxy model.
+	auto sortfilter_model = new LibrarySortFilterProxyModel(parent);
+	sortfilter_model->setDynamicSortFilter(false);
+	sortfilter_model->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+	retval.appendProxyModel(QPointer<LibrarySortFilterProxyModel>(sortfilter_model));
+
 	retval.appendView(new MDIPlaylistView(parent));
-    // qobject_cast<MDIPlaylistView*>(retval.m_view)->setModel(model);
 
 	return retval;
 }
 
 void MDIPlaylistView::setModel(QAbstractItemModel* model)
 {
-	// Keep a ref to the real model.
-	m_underlying_model = qobject_cast<PlaylistModel*>(model);
+	// Keep refs to the {proxy}models.
+	m_sortfilter_model = qobject_cast<LibrarySortFilterProxyModel*>(model);
+    Q_CHECK_PTR(m_sortfilter_model);
+	m_underlying_model = qobject_cast<PlaylistModel*>(m_sortfilter_model->sourceModel());
+	Q_CHECK_PTR(m_underlying_model);
 
-	if(m_underlying_model)
+	// Set our model URLs to the "current file".
+	/// @todo This is FBO the Playlist sidebar.  Should we keep the playlist model as a member of this class instead?
+	m_underlying_model->setLibraryRootUrl(m_current_url);
+
+	// m_sortfilter_model->setSourceModel(model);
+
+	// Set the top-level proxy model that this view will use.
+	// auto old_sel_model = selectionModel();
+	MDITreeViewBase::setModel(m_sortfilter_model);
+
+	// Call selectionChanged when the user changes the selection.
+	/// @todo selectionModel().selectionChanged.connect(selectionChanged)
+    // if(old_sel_model != nullptr)
+    // {
+    //     old_sel_model->deleteLater();
+    // }
+
+	// Set up the TreeView's header.
+	header()->setStretchLastSection(false);
+	header()->setSectionResizeMode(QHeaderView::Stretch);
+	header()->setContextMenuPolicy(Qt::CustomContextMenu);
+
+	// Set the resize behavior of the header's columns based on the columnspecs.
+	int num_cols = m_underlying_model->columnCount();
+	for(int c = 0; c < num_cols; ++c)
 	{
-		// Set our model URLs to the "current file".
-		/// @todo This is FBO the Playlist sidebar.  Should we keep the playlist model as a member of this class instead?
-		m_underlying_model->setLibraryRootUrl(m_current_url);
-
-		m_sortfilter_model->setSourceModel(model);
-
-		// Set the top-level proxy model that this view will use.
-		auto old_sel_model = selectionModel();
-		MDITreeViewBase::setModel(m_sortfilter_model);
-
-		// Call selectionChanged when the user changes the selection.
-		/// @todo selectionModel().selectionChanged.connect(selectionChanged)
-        if(old_sel_model != nullptr)
-        {
-            old_sel_model->deleteLater();
-        }
-
-		// Set up the TreeView's header.
-		header()->setStretchLastSection(false);
-		header()->setSectionResizeMode(QHeaderView::Stretch);
-		header()->setContextMenuPolicy(Qt::CustomContextMenu);
-
-		// Set the resize behavior of the header's columns based on the columnspecs.
-		int num_cols = m_underlying_model->columnCount();
-		for(int c = 0; c < num_cols; ++c)
+		if(m_underlying_model->headerData(c, Qt::Horizontal, ModelUserRoles::HeaderViewSectionShouldFitWidthToContents) == true)
 		{
-			if(m_underlying_model->headerData(c, Qt::Horizontal, ModelUserRoles::HeaderViewSectionShouldFitWidthToContents) == true)
-			{
-				header()->setSectionResizeMode(c, QHeaderView::ResizeToContents);
-			}
+			header()->setSectionResizeMode(c, QHeaderView::ResizeToContents);
 		}
-
-		// Find the "Length" column.
-		auto len_col = m_underlying_model->getColFromSection(SectionID::Length);
-		// Set the delegate on it.
-		setItemDelegateForColumn(len_col, m_length_delegate);
-
-		// Find the "Rating" column and set a delegate on it.
-		auto user_rating_col = m_underlying_model->getColFromSection(SectionID(PlaylistSectionID::Rating));
-		/// @todo setItemDelegateForColumn(user_rating_col, m_user_rating_delegate);
-
-		setEditTriggers(QAbstractItemView::DoubleClicked|QAbstractItemView::SelectedClicked);
 	}
-	else
-	{
-		qCr() << "Not a PlaylistModel:" << model;
-	}
+
+	// Find the "Length" column.
+	auto len_col = m_underlying_model->getColFromSection(SectionID::Length);
+	// Set the delegate on it.
+	setItemDelegateForColumn(len_col, m_length_delegate);
+
+	// Find the "Rating" column and set a delegate on it.
+	auto user_rating_col = m_underlying_model->getColFromSection(SectionID(PlaylistSectionID::Rating));
+	/// @todo setItemDelegateForColumn(user_rating_col, m_user_rating_delegate);
+
+	setEditTriggers(QAbstractItemView::DoubleClicked|QAbstractItemView::SelectedClicked);
 }
 
 QString MDIPlaylistView::getNewFilenameTemplate() const
@@ -193,8 +195,12 @@ QString MDIPlaylistView::defaultNameFilter()
 void MDIPlaylistView::setEmptyModel()
 {
 	/// @note This empty playlist model is parented to this.  Normally models are parented to the MainWindow.
+	MDIModelViewPair mvp;
 	auto new_playlist_model = new PlaylistModel(this);
-    setModel(new_playlist_model);
+	mvp.appendModel(new_playlist_model);
+	m_sortfilter_model = new LibrarySortFilterProxyModel(this);
+    mvp.appendProxyModel(m_sortfilter_model);
+    setModel(m_sortfilter_model);
 }
 
 void MDIPlaylistView::serializeDocument(QFileDevice& file)
@@ -395,7 +401,7 @@ void MDIPlaylistView::dropEvent(QDropEvent* event)
 
 PlaylistModel* MDIPlaylistView::underlyingModel() const
 {
-	return m_underlying_model.data();
+    return m_underlying_model;
 }
 
 

--- a/src/gui/MDIPlaylistView.cpp
+++ b/src/gui/MDIPlaylistView.cpp
@@ -495,8 +495,6 @@ void MDIPlaylistView::onDelete()
  */
 void MDIPlaylistView::onSendToNowPlaying(LibraryEntryMimeData* mime_data)
 {
-// M_WARNING("TODO: Dedup")
-
 	// We first need to convert the LibraryEntry's to a PlaylistModelItem's.
 	auto new_playlist_entries = toNewPlaylistModelItems(mime_data->m_lib_item_list);
 
@@ -508,8 +506,7 @@ void MDIPlaylistView::onSendToNowPlaying(LibraryEntryMimeData* mime_data)
 	}
 
 	// Dynamically cast the list to std::shared_ptr's to LibraryEntry's.
-// M_WARNING("/// @todo This seems terribly convoluted.  Seems like this view and model should only be caring about"
-// 		  "PlaylistModelEntry's");
+	/// @todo This seems terribly convoluted.  Seems like this view and model should only be caring about PlaylistModelEntry's
 	auto new_playlist_entries_as_libentry_ptrs = toLibraryEntrySharedPtrs(new_playlist_entries);
 
 	if(mime_data->m_drop_target_instructions.m_action == DropTargetInstructions::IDAE_REPLACE)
@@ -521,7 +518,7 @@ void MDIPlaylistView::onSendToNowPlaying(LibraryEntryMimeData* mime_data)
 
 	// This will be an append, so get the last row index of the View's model.
 	// That's the one we'll activate.
-// M_WARNING("TODO: This mostly works, but can start the wrong row if e.g. this view is sorted.  Proxy vs. Underlying model issue.");
+/// @TODO: This mostly works, but can start the wrong row if e.g. this view is sorted.  Proxy vs. Underlying model issue.
 	auto last_row = model()->rowCount();
 
 	// Append to underlying model.
@@ -545,7 +542,7 @@ void MDIPlaylistView::playlistPositionChanged(qint64 position)
 	// Notification from the QMediaPlaylist that the current selection has changed.
 	// Since we have a QSortFilterProxyModel between us and the underlying model, we need to convert the position,
 	// which is in underlying-model coordinates, to proxy model coordinates.
-#warning "TODO"
+	/// @TODO: Can this be deleted?
 	// auto proxy_model_index = from_underlying_qmodelindex(m_underlying_model->index(position, 0));
 
 	// @todo or should this change the selected index?

--- a/src/gui/MDIPlaylistView.h
+++ b/src/gui/MDIPlaylistView.h
@@ -132,14 +132,12 @@ protected Q_SLOTS:
 	void onContextMenuSelectedRows(QContextMenuEvent* event, const QPersistentModelIndexVec& row_indexes) override;
 	void onContextMenuViewport(QContextMenuEvent* event) override;
 
-
-
 private:
     Q_DISABLE_COPY(MDIPlaylistView)
 
     std::unique_ptr<DragDropTreeViewStyleProxy> m_the_dragdropstyleproxy;
 
-    QPointer<PlaylistModel> m_underlying_model;
+    PlaylistModel* m_underlying_model;
     LibrarySortFilterProxyModel* m_sortfilter_model;
     ItemDelegateLength* m_length_delegate;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1880,9 +1880,9 @@ void MainWindow::newNowPlaying()
 	/// so we always get an MDIModelViewPair here and don't need to hand-roll it.
 	MDIModelViewPair mvpair;
 	mvpair.appendModel(m_now_playing_playlist_model);
-	mvpair.appendProxyModel(m_now_playing_library_sortfilter_model);
 	mvpair.appendProxyModel(m_now_playing_shuffle_proxy_model);
-	mvpair.appendView(m_now_playing_playlist_view);
+    mvpair.appendProxyModel(m_now_playing_library_sortfilter_model);
+    mvpair.appendView(m_now_playing_playlist_view);
 	mvpair.m_view_was_existing = false;
 	mvpair.m_model_was_existing = false;
 
@@ -2082,7 +2082,9 @@ void MainWindow::addChildMDIModelViewPair_Playlist(const MDIModelViewPair& mvpai
 	if(mvpair.hasModel())
 	{
         qDb() << "ROOT MODEL TYPE IS:" << mvpair.getRootModel()->metaObject()->className();
-        auto proxy_model = qobject_cast<ShuffleProxyModel*>(mvpair.getTopModel());
+#warning "TODO Why did I comment this out?"
+		// auto proxy_model = qobject_cast<ShuffleProxyModel*>(mvpair.getTopModel());
+        auto proxy_model = qobject_cast<LibrarySortFilterProxyModel*>(mvpair.getTopModel());
         auto playlist_model = qobject_cast<PlaylistModel*>(proxy_model->sourceModel());
         Q_CHECK_PTR(playlist_model);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1171,9 +1171,6 @@ void MainWindow::connectPlayerAndNowPlayingView(MP2 *player, MDINowPlayingView *
 	// Connection for the player to tell the playlist to go to the next item when the current one is over.
 	// This in turn will cause a MDINowPlayingView::nowPlayingIndexChanged() to be emitted, which the player
 	// receives and sets up the now-current track.
-	// connect_or_die(player, &MP2::playlistToNext, now_playing_view, &MDINowPlayingView::next);
-	// connect_or_die(now_playing_view, &MDINowPlayingView::nowPlayingIndexChanged, player,
-	// 				&MP2::onPlaylistPositionChanged);
 	connect_or_die(player, &MP2::playlistToNext, m_now_playing_shuffle_proxy_model, &ShuffleProxyModel::next);
 	connect_or_die(m_now_playing_shuffle_proxy_model, &ShuffleProxyModel::nowPlayingIndexChanged, player, &MP2::onPlaylistPositionChanged);
 }
@@ -1185,7 +1182,6 @@ void MainWindow::connectPlayerControlsAndNowPlayingView(PlayerControls* controls
 	/// OR-ed in with any other connection type, which are 0,1,2,3.
     connect_or_die(controls, &PlayerControls::next, m_now_playing_shuffle_proxy_model, &ShuffleProxyModel::next, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
     connect_or_die(controls, &PlayerControls::previous, m_now_playing_shuffle_proxy_model, &ShuffleProxyModel::previous, Qt::ConnectionType(Qt::AutoConnection | Qt::UniqueConnection));
-	/// @todo Delete &MDINowPlayingView::shuffle
 	connect_or_die(controls, &PlayerControls::changeShuffle, m_now_playing_shuffle_proxy_model, &ShuffleProxyModel::setShuffle);
 	connect_or_die(controls, &PlayerControls::changeRepeat, m_now_playing_shuffle_proxy_model, &ShuffleProxyModel::setLoopAtEnd);
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -23,7 +23,6 @@
 #include <config.h>
 
 // Std C++
-
 #include <vector>
 #include <utility> // For std::pair<>
 #include <memory>
@@ -421,7 +420,7 @@ private:
 	QStandardItem* m_stditem_playlist_views;
 
     /// The library models.
-	std::vector<QPointer<LibraryModel>> m_libmodels;
+    std::vector<MDIModelViewPair*> m_libmodels;
 
 	QPointer<LibrarySortFilterProxyModel> m_libraryview_sort_filter_proxy_model;
 
@@ -435,7 +434,7 @@ private:
 	/// @}
 
     /// The list of PlaylistModels.
-	std::vector<QPointer<PlaylistModel>> m_playlist_models;
+    std::vector<MDIModelViewPair*> m_playlist_models;
 
     /// @}
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -34,6 +34,8 @@
 
 class ShuffleProxyModel;
 class LibrarySortFilterProxyModel;
+class PlaylistSortFilterProxyModel;
+class SelectionFilterProxyModel;
 
 class QActionGroup;
 class QWidget;
@@ -421,11 +423,16 @@ private:
     /// The library models.
 	std::vector<QPointer<LibraryModel>> m_libmodels;
 
-    /// The "Now Playing" playlist model and view.
+	QPointer<LibrarySortFilterProxyModel> m_libraryview_sort_filter_proxy_model;
+
+		/// @name The "Now Playing" playlist model and view.
+		/// @{
 	QPointer<PlaylistModel> m_now_playing_playlist_model;
 	QPointer<ShuffleProxyModel> m_now_playing_shuffle_proxy_model;
-	QPointer<LibrarySortFilterProxyModel> m_now_playing_sortfilter_model;
+	QPointer<LibrarySortFilterProxyModel> m_now_playing_library_sortfilter_model;
+	QPointer<PlaylistSortFilterProxyModel> m_now_playing_playlist_sortfilter_model;
 	QPointer<MDIPlaylistView> m_now_playing_playlist_view;
+	/// @}
 
     /// The list of PlaylistModels.
 	std::vector<QPointer<PlaylistModel>> m_playlist_models;

--- a/src/gui/mdi/MDIModelViewPair.cpp
+++ b/src/gui/mdi/MDIModelViewPair.cpp
@@ -37,6 +37,8 @@ void MDIModelViewPair::appendView(QPointer<MDITreeViewBase> view)
 	}
 	m_view = view;
 
+	Q_ASSERT(m_model_stack.size() > 1);
+
 	m_view->setModel(m_model_stack.back());
 }
 
@@ -53,4 +55,9 @@ bool MDIModelViewPair::hasView() const
 bool MDIModelViewPair::hasModelAndView() const
 {
 	return (!m_model_stack.empty()) && m_view;
+}
+
+QPointer<QAbstractItemModel> MDIModelViewPair::getProxyAt(int proxymodel) const
+{
+	return m_model_stack.at(proxymodel+1);
 }

--- a/src/gui/mdi/MDIModelViewPair.cpp
+++ b/src/gui/mdi/MDIModelViewPair.cpp
@@ -16,15 +16,33 @@
  * You should have received a copy of the GNU General Public License
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
+/**
+ * @file
+ */
 
 #include "MDIModelViewPair.h"
 
 #include <QAbstractItemModel>
 #include "gui/MDITreeViewBase.h"
 
+void MDIModelViewPair::appendView(QPointer<MDITreeViewBase> view)
+{
+	if (!m_view.isNull())
+	{
+		qFatal("MDIModelViewPair::appendView: Already have a view.");
+	}
+	if (m_model_stack.empty())
+	{
+		qFatal("MDIModelViewPair::appendView: No model.");
+	}
+	m_view = view;
+
+	m_view->setModel(m_model_stack.back());
+}
+
 bool MDIModelViewPair::hasModel() const
 {
-	return m_model;
+	return !m_model_stack.empty();
 }
 
 bool MDIModelViewPair::hasView() const
@@ -34,5 +52,5 @@ bool MDIModelViewPair::hasView() const
 
 bool MDIModelViewPair::hasModelAndView() const
 {
-	return m_model && m_view;
+	return (!m_model_stack.empty()) && m_view;
 }

--- a/src/gui/mdi/MDIModelViewPair.h
+++ b/src/gui/mdi/MDIModelViewPair.h
@@ -25,6 +25,7 @@
 
 // Std C++.
 #include <vector>
+#include <concepts>
 
 // Qt
 #include <QAbstractProxyModel>
@@ -37,7 +38,7 @@ class MDITreeViewBase;
 
 
 /**
- * Object which olds:
+ * Object which holds:
  * - A model
  * - A stack of proxy models on top of the model
  * - A view on top of the proxy models
@@ -48,13 +49,13 @@ class MDIModelViewPair
 public:
 
 	template <typename T>
-		requires (!std::is_convertible_v<T*, QAbstractProxyModel*>)
-	void appendModel(QPointer<T> model)
+        requires (std::convertible_to<T, QAbstractItemModel*> && !std::convertible_to<T, QAbstractProxyModel*>)
+    void appendModel(T model)
 	{
 		// For now anyway, this should only push a model to the bottom of the {proxy}model stack.
 		if (!m_model_stack.empty())
 		{
-            qCr() << "Model wasn't the first item pushed onto the modelstack:" << model.get();
+            qCr() << "Model wasn't the first item pushed onto the modelstack";
 		}
 
 		m_model_stack.emplace_back(model);
@@ -62,18 +63,18 @@ public:
 
 	/**
 	 * Append a proxy model to the top of the model stack.
-	 * Note that @a proxymodel is setSourceModel()'d to the top {proxy}model in the stack, but no other
+     * Note that @a proxymodel is setSourceModel()'d to the current top {proxy}model in the stack, but no other
 	 * connections are made.
 	 * @tparam T
 	 * @param proxymodel
 	 */
 	template <typename T>
-		requires std::is_convertible_v<T*, QAbstractProxyModel*>
-	void appendProxyModel(QPointer<T> proxymodel)
+        requires (std::convertible_to<T, QAbstractProxyModel*>)
+    void appendProxyModel(T proxymodel)
 	{
 		if (m_model_stack.empty())
 		{
-            qCr() << "No model to connect ProxyModel to:" << proxymodel.get();
+            qCr() << "No model to connect ProxyModel to";
 		}
 
 		m_model_stack.emplace_back(proxymodel);

--- a/src/gui/mdi/MDIModelViewPair.h
+++ b/src/gui/mdi/MDIModelViewPair.h
@@ -46,26 +46,14 @@ class MDIModelViewPair
 {
 public:
 
-	// template <typename T>
-	// void setModel(T* derived_model_ptr)
-	// {
-	// 	m_model_stack = derived_model_ptr;
-	// }
-	//
-	// template <typename T>
-	// void setModel(QPointer<T> derived_model_ptr)
-	// {
-	// 	m_model_stack = derived_model_ptr;
-	// }
-
 	template <typename T>
-		requires (!std::is_convertible_v<QAbstractProxyModel*, T*>)
+		requires (!std::is_convertible_v<T*, QAbstractProxyModel*>)
 	void appendModel(QPointer<T> model)
 	{
 		// For now anyway, this should only push a model to the bottom of the {proxy}model stack.
 		if (!m_model_stack.empty())
 		{
-			qCr() << "Model wasn't the first item pushed onto the modelstack:" << model;
+            qCr() << "Model wasn't the first item pushed onto the modelstack:" << model.get();
 		}
 
 		m_model_stack.emplace_back(model);
@@ -79,12 +67,12 @@ public:
 	 * @param proxymodel
 	 */
 	template <typename T>
-		requires std::is_convertible_v<QAbstractProxyModel*, T*>
+		requires std::is_convertible_v<T*, QAbstractProxyModel*>
 	void appendProxyModel(QPointer<T> proxymodel)
 	{
 		if (m_model_stack.empty())
 		{
-			qCr() << "No model to connect ProxyModel to:" << proxymodel;
+            qCr() << "No model to connect ProxyModel to:" << proxymodel.get();
 		}
 
 		m_model_stack.emplace_back(proxymodel);
@@ -100,6 +88,12 @@ public:
 
 	QPointer<MDITreeViewBase> getView() const { return m_view; }
     QPointer<QAbstractItemModel> getTopModel() const { return m_model_stack.back(); }
+
+	/**
+	 * @todo Seems like this should go away eventually.
+	 * @return
+	 */
+    QPointer<QAbstractItemModel> getRootModel() const { return m_model_stack.front(); }
 
 private:
 	std::vector<QPointer<QAbstractItemModel>> m_model_stack;

--- a/src/gui/mdi/MDIModelViewPair.h
+++ b/src/gui/mdi/MDIModelViewPair.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, 2018 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2017, 2018, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *

--- a/src/gui/mdi/MDIModelViewPair.h
+++ b/src/gui/mdi/MDIModelViewPair.h
@@ -44,6 +44,7 @@ class MDITreeViewBase;
  */
 class MDIModelViewPair
 {
+
 public:
 
 	template <typename T>
@@ -94,6 +95,8 @@ public:
 	 * @return
 	 */
     QPointer<QAbstractItemModel> getRootModel() const { return m_model_stack.front(); }
+
+	QPointer<QAbstractItemModel> getProxyAt(int proxymodel) const;
 
 private:
 	std::vector<QPointer<QAbstractItemModel>> m_model_stack;

--- a/src/logic/LibraryRescanner.h
+++ b/src/logic/LibraryRescanner.h
@@ -94,6 +94,10 @@ Q_SIGNALS:
 
 	void SIGNAL_appendChild(std::shared_ptr<AbstractTreeModelItem> new_child, UUIncD parent_id);
 
+    void SIGNAL_onIncomingPopulateRowWithItems_Multiple(QPersistentModelIndex, std::vector<std::shared_ptr<LibraryEntry>>);
+
+    void SIGNAL_setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+
 public:
 	explicit LibraryRescanner(LibraryModel* parent);
 	~LibraryRescanner() override;

--- a/src/logic/MP2.cpp
+++ b/src/logic/MP2.cpp
@@ -17,7 +17,9 @@
  * along with AwesomeMediaLibraryManager.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/// @file
+/**
+ * @file
+ */
 
 #include "MP2.h"
 
@@ -174,7 +176,6 @@ void MP2::seek(int msecs)
 {
 	msecs += m_track_startpos_ms;
 	// Clamp it to end-1 so we don't cause a transition to the next song while we're seeking.
-	/// @todo Except this doesn't work.
 	if (msecs>=m_track_endpos_ms)
 	{
 		msecs -= 1;

--- a/src/logic/jobs/LibraryRescannerJob.cpp
+++ b/src/logic/jobs/LibraryRescannerJob.cpp
@@ -161,8 +161,8 @@ void library_metadata_rescan_task(QPromise<MetadataReturnVal>& promise, AMLMJob*
 		promise.suspendIfRequested();
 		if (promise.isCanceled())
 		{
-			// We've been cancelled.
-			qIn() << "CANCELLED";
+			// We've been canceled.
+			qIn() << "CANCELED";
 			return;
 		}
 

--- a/src/logic/models/LibraryEntryMimeData.h
+++ b/src/logic/models/LibraryEntryMimeData.h
@@ -51,15 +51,24 @@ public:
 
 	enum PostAddActionEnumerator
 	{
+		/// Take no action.
 		PA_NONE,
+		/// Start playing what was dropped.
 		PA_START_PLAYING,
+		/// Start playing what was dropped, but only if the playlist was not being played at drop time.
+		/// @todo Unused
+		PA_START_PLAYING_IF_STOPPED,
 	};
 	Q_ENUM(PostAddActionEnumerator)
 
-	/// Which item disposition action to take.
+	/**
+	 * Which item disposition action to take.
+	 */
 	ItemDispositionActionEnumerator m_action { IDAE_NA };
 
-	/// Whether to start playing or not.
+	/**
+	 * Whether to start playing or not.
+	 */
 	PostAddActionEnumerator m_start_playing { PA_NONE };
 };
 

--- a/src/logic/models/LibraryModel.cpp
+++ b/src/logic/models/LibraryModel.cpp
@@ -100,10 +100,9 @@ LibraryModel::~LibraryModel()
     m_rescanner->deleteLater();
 }
 
+// static
 QPointer<LibraryModel> LibraryModel::openFile(QUrl open_url, QObject* parent)
 {
-	// This is static.
-
     // Create the new LibraryModel.
 	auto lib = QPointer<LibraryModel>(new LibraryModel(parent));
 

--- a/src/logic/models/PlaylistModel.cpp
+++ b/src/logic/models/PlaylistModel.cpp
@@ -209,6 +209,8 @@ bool PlaylistModel::setData(const QModelIndex& index, const QVariant& value, int
 		qCritical() << "CANT CONVERT to PlaylistModelItem*:" << value;
 		//Q_ASSERT(0);
 	}
+
+	/// @TODO: Is this even a valid thing to try to do here?
 	qDebug() << "PUNTING TO BASE CLASS";
 
 	retval = LibraryModel::setData(index, value, role);

--- a/src/logic/proxymodels/LibrarySortFilterProxyModel.cpp
+++ b/src/logic/proxymodels/LibrarySortFilterProxyModel.cpp
@@ -25,7 +25,10 @@
 
 LibrarySortFilterProxyModel::LibrarySortFilterProxyModel(QObject* parent) : QSortFilterProxyModel(parent)
 {
-	setObjectName("LibrarySortFilterProxyModel#");
+	static int id = 0;
+	std::string name = std::format("LibrarySortFilterProxyModel{}", id);
+	id++;
+	setObjectName(name.c_str());
 	// Filter all columns by default.
 	setFilterKeyColumn(-1);
 }

--- a/src/logic/proxymodels/ModelHelpers.cpp
+++ b/src/logic/proxymodels/ModelHelpers.cpp
@@ -21,13 +21,12 @@
 #include "ModelHelpers.h"
 
 
-
 QModelIndex mapToSourceRecursive(const QModelIndex& proxy_index)
 {
-    if(!proxy_index.isValid())
-    {
-        return QModelIndex();
-    }
+	if (!proxy_index.isValid())
+	{
+		return QModelIndex();
+	}
 
 	if (proxy_index.model())
 	{
@@ -36,7 +35,7 @@ QModelIndex mapToSourceRecursive(const QModelIndex& proxy_index)
 		if (proxy_model)
 		{
 			// recurse into the next proxy model.
-            return mapToSourceRecursive(proxy_model->mapToSource(proxy_index));
+			return mapToSourceRecursive(proxy_model->mapToSource(proxy_index));
 		}
 		// We've hit the true source model.
 		return proxy_index;
@@ -69,10 +68,27 @@ QModelIndexList mapToSourceRecursive(const QModelIndexList& source_indices)
 {
 	QModelIndexList retval;
 
-	for(const auto& i : source_indices)
+	for (const auto& i : source_indices)
 	{
 		retval.push_back(mapToSourceRecursive(i));
 	}
 
 	return retval;
+}
+
+QAbstractItemModel* getRootModel(QAbstractItemModel* maybe_proxy_model)
+{
+	auto proxy_model = qobject_cast<QAbstractProxyModel*>(maybe_proxy_model);
+
+	if (proxy_model && proxy_model->sourceModel())
+	{
+		// It's a proxymodel with a source model, so recurse on the source model.
+		auto source_model = proxy_model->sourceModel();
+		return getRootModel(source_model);
+	}
+	else
+	{
+		// Wasn't a proxy model.
+		return maybe_proxy_model;
+	}
 }

--- a/src/logic/proxymodels/ModelHelpers.h
+++ b/src/logic/proxymodels/ModelHelpers.h
@@ -125,35 +125,11 @@ T<QPersistentModelIndex> mapQPersistentModelIndexesToSource(const T<QPersistentM
 }
 
 /**
- * @warning I'm not sure this is correct.
+ * Returns the bottom-most model in a model<-proxy<-proxy...<-proxy chain.
  * @param maybe_proxy_model
  * @return
  */
-inline static QAbstractItemModel* getRootModel(QAbstractItemModel* maybe_proxy_model)
-{
-	auto proxy_model = qobject_cast<QAbstractProxyModel*>(maybe_proxy_model);
-
-	if(proxy_model)
-	{
-		qDebug() << "Is a proxy model:" << proxy_model;
-		auto source_model = proxy_model->sourceModel();
-		if(source_model)
-		{
-			qDebug() << "With source model:" << source_model;
-			return (QAbstractItemModel*)source_model;
-		}
-		else
-		{
-			return maybe_proxy_model;
-		}
-	}
-	else
-	{
-		// Wasn't a proxy model.
-		qDebug() << "Not a proxy model:" << maybe_proxy_model;
-		return maybe_proxy_model;
-	}
-}
+QAbstractItemModel* getRootModel(QAbstractItemModel* maybe_proxy_model);
 
 #endif /* MODELHELPERS_H */
 

--- a/src/logic/proxymodels/SelectionFilterProxyModel.cpp
+++ b/src/logic/proxymodels/SelectionFilterProxyModel.cpp
@@ -25,8 +25,11 @@
 
 SelectionFilterProxyModel::SelectionFilterProxyModel(QObject *parent) : BASE_CLASS(parent)
 {
-	setObjectName("SelectionFilterProxyModel#");
+	static int id = 0;
+	std::string name = std::format("SelectionFilterProxyModel{}", id);
+	setObjectName(name.c_str());
 	setDynamicSortFilter(true);
+	++id;
 }
 
 SelectionFilterProxyModel::~SelectionFilterProxyModel()

--- a/src/logic/proxymodels/ShuffleProxyModel.cpp
+++ b/src/logic/proxymodels/ShuffleProxyModel.cpp
@@ -36,7 +36,10 @@
 
 ShuffleProxyModel::ShuffleProxyModel(QObject* parent): QSortFilterProxyModel(parent)
 {
-	setObjectName("ShuffleProxyModel");
+	static int id = 0;
+	std::string name = std::format("ShuffleProxyModel{}", id);
+	++id;
+	setObjectName(name.c_str());
 
 	m_sel_model = new QItemSelectionModel(this);
 	connect_or_die(m_sel_model, &QItemSelectionModel::selectionChanged, this,

--- a/src/logic/proxymodels/ShuffleProxyModel.cpp
+++ b/src/logic/proxymodels/ShuffleProxyModel.cpp
@@ -32,6 +32,7 @@
 
 // Ours
 #include <ConnectHelpers.h>
+#include <ModelHelpers.h>
 
 
 ShuffleProxyModel::ShuffleProxyModel(QObject* parent): QSortFilterProxyModel(parent)
@@ -129,20 +130,22 @@ void ShuffleProxyModel::onNumRowsChanged()
 	{
 		// Went from empty Now Playing to non-empty.  Set a current item and selected item,
 		// so that the play button works.
-		// QTimer stuff here because this is segfaulting:
-		// selectionModel()->select(model()->index(0, 0),
-		//           QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
-  // QTimer::singleShot(0, this, [this]()
-		// {
+		// QTimer stuff here because if we just call nowPlayingIndexChanged() directly here,
+		// drops/copies are slightly broken.  Without the timer, when you copy or drop items into NowPlaying,
+		// an empty QUrl gets sent to MP2::onPlaylistPositionChanged() and MP2::onSourceChanged(), due to the initial
+		// LibraryModel::insertRows() inserting default-constructed rows.
+		// I'm not wild about using the timer, but onDataChanged doesn't seem to be enough nor get through to MP2.
+		QTimer::singleShot(0, this, [this]()
+		{
 			m_current_shuffle_index = m_indices.at(0);
-            Q_EMIT nowPlayingIndexChanged(sourceModel()->index(0,0), QModelIndex(), false);
-		// });
+			Q_EMIT nowPlayingIndexChanged(sourceModel()->index(0, 0), QModelIndex(), false);
+		});
 	}
 }
 
 static bool isInDataChangedRange(const QModelIndex& testIndex,
-						const QModelIndex& topLeft,
-						const QModelIndex& bottomRight)
+								const QModelIndex& topLeft,
+								const QModelIndex& bottomRight)
 {
 	return testIndex.isValid() &&
 		testIndex.model() == topLeft.model() &&
@@ -153,6 +156,7 @@ static bool isInDataChangedRange(const QModelIndex& testIndex,
 		testIndex.column() <= bottomRight.column();
 }
 
+// slot
 void ShuffleProxyModel::onDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight,
 									const QList<int>& roles)
 {
@@ -279,7 +283,7 @@ void ShuffleProxyModel::connectToModel(QAbstractItemModel* model)
 			<< connect_or_die(model, &QAbstractItemModel::modelReset, this, &ShuffleProxyModel::onNumRowsChanged)
 			<< connect_or_die(model, &QAbstractItemModel::rowsInserted, this, &ShuffleProxyModel::onNumRowsChanged)
 			<< connect_or_die(model, &QAbstractItemModel::rowsRemoved, this, &ShuffleProxyModel::onNumRowsChanged)
-			<< connect_or_die(model, &QAbstractItemModel::dataChanged, this, &ShuffleProxyModel::onDataChanged);
+			<< connect_or_die(getRootModel(model), &QAbstractItemModel::dataChanged, this, &ShuffleProxyModel::onDataChanged);
 	}
 }
 
@@ -288,7 +292,6 @@ void ShuffleProxyModel::resetInternalData()
 	m_currentIndex = QModelIndex();
 	m_shuffle = false;
 	m_loop_at_end = true;
-	// m_shuffle_model_rows = false;
 	m_current_shuffle_index = -1;
 	m_indices.clear();
 	m_disconnector.disconnect();

--- a/src/utils/ConnectHelpers.cpp
+++ b/src/utils/ConnectHelpers.cpp
@@ -36,6 +36,7 @@ Disconnector::~Disconnector()
 
 void Disconnector::addConnection(QMetaObject::Connection connection)
 {
+	Q_ASSERT(true == static_cast<bool>(connection));
 	m_connections.push_back(connection);
 }
 

--- a/src/utils/ConnectHelpers.h
+++ b/src/utils/ConnectHelpers.h
@@ -85,8 +85,8 @@ connect_or_die(const T t, TPMF tpmf, const U u, UPMF upmf, Qt::ConnectionType co
     QMetaObject::Connection retval;
 
 	// Assert off the bat if we get null ptrs.
-	// Q_CHECK_PTR(t);
-	// Q_CHECK_PTR(u);
+	Q_CHECK_PTR(t);
+	Q_CHECK_PTR(u);
 
     retval = QObject::connect(t, tpmf, u, upmf, Qt::ConnectionType(connection_type | Qt::UniqueConnection));
     Q_ASSERT(static_cast<bool>(retval) != false);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -142,6 +142,7 @@ target_link_libraries(${TEST_EXE_TARGET}
 		${PROJECT_COMMON_LINK_LIBS}
 #		${QT_LINK_LIB_TARGETS}
 		${KF_LINK_LIB_TARGETS}
+		stdc++exp
 )
 add_test(NAME ${TEST_EXE_TARGET} COMMAND $<TARGET_FILE:${TEST_EXE_TARGET}>)
 ecm_mark_as_test(${TEST_EXE_TARGET})


### PR DESCRIPTION
- Beefed up MDIModelViewPair to better support arbitrary number of proxy models.
- Resolved situation where Paste-to-empty-NowPlaying would bold the text of the first item, but not play the first item when the play button was triggered.
- Improved the ownership situation of models and proxy models.
- Added uniqueified objectName()s to a number of view and {proxy}model classes.