### PR TITLE
Chore/66 fix option is valid for cobjc but not for c warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,13 +86,6 @@ set(FULL_COPYRIGHT_STRING "Copyright (c) 2017, 2018, 2019, 2024, 2025 ${PROJECT_
 
 # Early include of some basic cmake stuff.
 include(CMakePrintHelpers)
-file(WRITE "${CMAKE_BINARY_DIR}/compile_options_report.txt" "")
-function(record_options target)
-	get_target_property(opts ${target} INTERFACE_COMPILE_OPTIONS)
-	file(APPEND "${CMAKE_BINARY_DIR}/compile_options_report.txt"
-		"Target: ${target}\nOptions: ${opts}\n\n")
-endfunction()
-
 
 ### Set the required language standards.
 # C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ if(UNIX)
 	)
 	target_compile_definitions(cxx_definitions_qt
 		INTERFACE
-			$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+#			$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 	)
 #	ucm_add_flags(-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
 #		-fno-eliminate-unused-debug-types -fno-inline -fmodules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ set(FULL_COPYRIGHT_STRING "Copyright (c) 2017, 2018, 2019, 2024, 2025 ${PROJECT_
 
 # Early include of some basic cmake stuff.
 include(CMakePrintHelpers)
+file(WRITE "${CMAKE_BINARY_DIR}/compile_options_report.txt" "")
+function(record_options target)
+	get_target_property(opts ${target} INTERFACE_COMPILE_OPTIONS)
+	file(APPEND "${CMAKE_BINARY_DIR}/compile_options_report.txt"
+		"Target: ${target}\nOptions: ${opts}\n\n")
+endfunction()
+
 
 ### Set the required language standards.
 # C
@@ -203,8 +210,6 @@ include(ECMQtDeclareLoggingCategory)
 ###
 
 # Set some extra debug flags early.
-# This is stupid, but I can't for the life of me figure out a better way to set the compiler options in
-# cmake and/or Qt Creator.
 # https://github.com/onqtam/ucm#ucm_add_flags
 include(ucm)
 # Target-focused compile settings.
@@ -217,10 +222,16 @@ target_compile_options(cxx_compile_options INTERFACE)
 if(UNIX)
 	target_compile_options(cxx_compile_options
 		INTERFACE
-			-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-		-fno-eliminate-unused-debug-types -fno-inline -fmodules)
-	ucm_add_flags(-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-		-fno-eliminate-unused-debug-types -fno-inline -fmodules)
+#			$<$<CONFIG:Debug>:-Og -ggdb3 -fno-omit-frame-pointer -Werror=return-type -fno-eliminate-unused-debug-types -fno-inline>
+			$<$<COMPILE_LANGUAGE:CXX>:-fmodules>
+#			-fmessage-length=0 -pthread
+	)
+	target_compile_definitions(cxx_definitions_qt
+		INTERFACE
+			$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+	)
+#	ucm_add_flags(-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
+#		-fno-eliminate-unused-debug-types -fno-inline -fmodules)
 # Flags for GNU libstdc++
 ### @todo Detect that we're actually using GNU libstdc++
 # "compiles user code using the debug mode. When defined, _GLIBCXX_ASSERTIONS is defined automatically"
@@ -234,17 +245,19 @@ if(FALSE) ##CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	message(STATUS "C++ Compiler is GCC")
-	ucm_add_flags(-fvar-tracking -fvar-tracking-assignments -gpubnames -ggnu-pubnames)
+	ucm_add_flags(CXX -fvar-tracking -fvar-tracking-assignments -gpubnames -ggnu-pubnames CONFIG DEBUG)
 	# Max debug flags
 	target_compile_options(cxx_compile_options
 		INTERFACE
-			-gvariable-location-views
-			-gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any
+#			$<$<COMPILE_LANGUAGE:CXX>:-fdiagnostics-show-template-tree>
+#			-gvariable-location-views
+#			-gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any
 		)
-	#ucm_add_flags(-gvariable-location-views)
-	ucm_add_flags(-grecord-gcc-switches)
-	ucm_add_flags(-fno-eliminate-unused-debug-types -fno-inline)
-	ucm_add_flags(-Wmaybe-uninitialized -Werror=maybe-uninitialized -fdiagnostics-show-template-tree -fdiagnostics-show-option)
+	ucm_add_flags(CXX -grecord-gcc-switches)
+#	ucm_add_flags(-fno-eliminate-unused-debug-types -fno-inline)
+	ucm_add_flags(
+		-Wmaybe-uninitialized -Werror=maybe-uninitialized
+		-fdiagnostics-show-option)
 	ucm_add_flags(-fuse-ld=gold) # Let's try the gold linker.
 	# GCC 9.x suggestions.
 	add_library(cxx_suggestions INTERFACE)
@@ -278,7 +291,8 @@ message(STATUS "C compiler supported features = ${CMAKE_C_COMPILE_FEATURES}")
 message(STATUS "C++ compiler supported features = ${CMAKE_CXX_COMPILE_FEATURES}")
 message(STATUS "C++ CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
 message(STATUS "C++ CMAKE_CXX_FLAGS_DEBUG = ${CMAKE_CXX_FLAGS_DEBUG}")
-
+message(STATUS "UCM_PRINT_FLAGS():")
+ucm_print_flags()
 ###
 
 
@@ -323,7 +337,7 @@ message("* Using CMake version ${CMAKE_VERSION}")
 message("* CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
 message("*")
 message("* From top level:")
-message("*   Source directory: ${PROJECT_SOURCE_DIR} (${AwesomeMediaLibraryManager_SOURCE_DIR})")
+message("*   Top level source directory: ${PROJECT_SOURCE_DIR} (${AwesomeMediaLibraryManager_SOURCE_DIR})")
 message("*   Top level of build tree: ${CMAKE_BINARY_DIR}")
 message("*   Build directory: ${PROJECT_BINARY_DIR} (${AwesomeMediaLibraryManager_BINARY_DIR})")
 message("*   Version: ${PROJECT_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ include(ECMQtDeclareLoggingCategory)
 ### END ECM Setup ====================================================================================================
 ###
 
-# Set some extra debug flags early.
+# Set the basic compile flags early.
 # https://github.com/onqtam/ucm#ucm_add_flags
 include(ucm)
 # Target-focused compile settings.
@@ -213,18 +213,18 @@ target_compile_definitions(cxx_definitions_qt INTERFACE)
 add_library(cxx_compile_options INTERFACE)
 target_compile_options(cxx_compile_options INTERFACE)
 if(UNIX)
-	target_compile_options(cxx_compile_options
-		INTERFACE
-#			$<$<CONFIG:Debug>:-Og -ggdb3 -fno-omit-frame-pointer -Werror=return-type -fno-eliminate-unused-debug-types -fno-inline>
-			$<$<COMPILE_LANGUAGE:CXX>:-fmodules>
-#			-fmessage-length=0 -pthread
-	)
-	target_compile_definitions(cxx_definitions_qt
-		INTERFACE
-#			$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
-	)
-#	ucm_add_flags(-Og -ggdb3 -fno-omit-frame-pointer -fmessage-length=0 -pthread -Werror=return-type
-#		-fno-eliminate-unused-debug-types -fno-inline -fmodules)
+	# C base flags
+	ucm_add_flags(C -Og -ggdb3 -fmessage-length=0 -pthread)
+	# C++ base flags
+	ucm_add_flags(CXX -Og -ggdb3 -fmessage-length=0 -pthread -Werror=return-type -fmodules -fdiagnostics-show-option)
+	# C++ Additional Debug flags
+	ucm_add_flags(CXX -Og -ggdb3 -fno-omit-frame-pointer -fno-eliminate-unused-debug-types -fno-inline
+		-fdiagnostics-show-template-tree
+		CONFIG Debug)
+#	target_compile_definitions(cxx_definitions_qt
+#		INTERFACE
+##			$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+#	)
 # Flags for GNU libstdc++
 ### @todo Detect that we're actually using GNU libstdc++
 # "compiles user code using the debug mode. When defined, _GLIBCXX_ASSERTIONS is defined automatically"
@@ -238,20 +238,14 @@ if(FALSE) ##CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	message(STATUS "C++ Compiler is GCC")
-	ucm_add_flags(CXX -fvar-tracking -fvar-tracking-assignments -gpubnames -ggnu-pubnames CONFIG DEBUG)
-	# Max debug flags
-	target_compile_options(cxx_compile_options
-		INTERFACE
-#			$<$<COMPILE_LANGUAGE:CXX>:-fdiagnostics-show-template-tree>
-#			-gvariable-location-views
-#			-gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any
-		)
-	ucm_add_flags(CXX -grecord-gcc-switches)
-#	ucm_add_flags(-fno-eliminate-unused-debug-types -fno-inline)
-	ucm_add_flags(
+	# GCC-specific debug flags
+	ucm_add_flags(CXX -fvar-tracking -fvar-tracking-assignments -gpubnames -ggnu-pubnames -gvariable-location-views
+		-gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any
+		-ftrack-macro-expansion
 		-Wmaybe-uninitialized -Werror=maybe-uninitialized
-		-fdiagnostics-show-option)
-	ucm_add_flags(-fuse-ld=gold) # Let's try the gold linker.
+		-grecord-gcc-switches
+		CONFIG DEBUG)
+	ucm_add_flags(-fuse-ld=gold) # Let's use the gold linker.
 	# GCC 9.x suggestions.
 	add_library(cxx_suggestions INTERFACE)
 	target_compile_options(cxx_suggestions INTERFACE
@@ -261,10 +255,10 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 	message(STATUS "C++ Compiler is Clang")
 	target_compile_options(cxx_compile_options
 		INTERFACE
-			-fforce-emit-vtables
-			)
-	ucm_add_flags(-Wthread-safety -fdebug-macro -fdiagnostics-show-template-tree -mno-omit-leaf-frame-pointer -ftime-trace=build_time_trace.json)
-	#ucm_add_flags(-fdelayed-template-parsing -frelaxed-template-template-args)
+	)
+	ucm_add_flags(CXX -Wthread-safety -fforce-emit-vtables -fdebug-macro
+		-mno-omit-leaf-frame-pointer -ftime-trace=build_time_trace.json
+		CONFIG Debug)
 endif()
 if(WIN32)
 	#ucm_add_flags(/showIncludes)
@@ -279,7 +273,6 @@ if(WIN32)
 endif(WIN32)
 target_link_libraries(cxx_settings INTERFACE cxx_compile_options)
 
-#set(CMAKE_CXX_FLAGS_DEBUG "-ggdb3 -ftime-trace")
 message(STATUS "C compiler supported features = ${CMAKE_C_COMPILE_FEATURES}")
 message(STATUS "C++ compiler supported features = ${CMAKE_CXX_COMPILE_FEATURES}")
 message(STATUS "C++ CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,21 @@
+{
+  "version": 10,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default",
+      "description": "Default build options for GCC-compatible compilers",
+      "binaryDir": "${sourceDir}/build-clion-debug",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-Og -ggdb3",
+        "CMAKE_CXX_FLAGS": "-Og -ggdb3 -fmessage-length=0 -pthread",
+        "CMAKE_CXX_FLAGS_DEBUG": "-Og -ggdb3 -fno-omit-frame-pointer -Werror=return-type -fno-eliminate-unused-debug-types -fno-inline -fdiagnostics-show-template-tree -gvariable-location-views -gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE"
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,9 +12,10 @@
       "description": "Default build options for GCC-compatible compilers",
       "binaryDir": "${sourceDir}/build-clion-debug",
       "cacheVariables": {
-        "CMAKE_C_FLAGS": "-Og -ggdb3",
+        "CMAKE_C_FLAGS": "-Og -ggdb3 -fmessage-length=0",
         "CMAKE_CXX_FLAGS": "-Og -ggdb3 -fmessage-length=0 -pthread -Werror=return-type -fmodules",
-        "CMAKE_CXX_FLAGS_DEBUG": "-Og -ggdb3 -fno-omit-frame-pointer -fno-eliminate-unused-debug-types -fno-inline -fdiagnostics-show-template-tree -gvariable-location-views -gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE"
+        "CMAKE_CXX_FLAGS_DEBUG": "-Og -ggdb3 -fno-omit-frame-pointer -fno-eliminate-unused-debug-types -fno-inline -fdiagnostics-show-template-tree -gvariable-location-views -gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any",
+        "$comment": ",-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE"
       }
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,8 +13,8 @@
       "binaryDir": "${sourceDir}/build-clion-debug",
       "cacheVariables": {
         "CMAKE_C_FLAGS": "-Og -ggdb3",
-        "CMAKE_CXX_FLAGS": "-Og -ggdb3 -fmessage-length=0 -pthread",
-        "CMAKE_CXX_FLAGS_DEBUG": "-Og -ggdb3 -fno-omit-frame-pointer -Werror=return-type -fno-eliminate-unused-debug-types -fno-inline -fdiagnostics-show-template-tree -gvariable-location-views -gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE"
+        "CMAKE_CXX_FLAGS": "-Og -ggdb3 -fmessage-length=0 -pthread -Werror=return-type -fmodules",
+        "CMAKE_CXX_FLAGS_DEBUG": "-Og -ggdb3 -fno-omit-frame-pointer -fno-eliminate-unused-debug-types -fno-inline -fdiagnostics-show-template-tree -gvariable-location-views -gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE"
       }
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,9 +12,9 @@
       "description": "Default build options for GCC-compatible compilers",
       "binaryDir": "${sourceDir}/build-clion-debug",
       "cacheVariables": {
-        "CMAKE_C_FLAGS": "-Og -ggdb3 -fmessage-length=0",
-        "CMAKE_CXX_FLAGS": "-Og -ggdb3 -fmessage-length=0 -pthread -Werror=return-type -fmodules",
-        "CMAKE_CXX_FLAGS_DEBUG": "-Og -ggdb3 -fno-omit-frame-pointer -fno-eliminate-unused-debug-types -fno-inline -fdiagnostics-show-template-tree -gvariable-location-views -gas-loc-support -gas-locview-support -gstatement-frontiers -ginline-points -femit-struct-debug-detailed=any",
+        "CMAKE_C_FLAGS": "",
+        "CMAKE_CXX_FLAGS": "",
+        "CMAKE_CXX_FLAGS_DEBUG": "",
         "$comment": ",-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE"
       }
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,7 +267,7 @@ target_compile_definitions(${PROJECT_NAME}
 	PUBLIC
 		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
 		# Enable the libstdc++ debug mode.
-		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+#		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 		"KXMLGUI_NO_DEPRECATED=1"
 	)
 target_include_directories(${PROJECT_NAME}
@@ -294,21 +294,6 @@ target_link_libraries(${PROJECT_NAME}
 		libapp
 		stdc++exp # For debug backtrace in the std lib.
 )
-
-record_options(${PROJECT_NAME})
-
-function(print_target_options target)
-	get_target_property(opts ${target} COMPILE_OPTIONS)
-	get_target_property(interface_opts ${target} INTERFACE_COMPILE_OPTIONS)
-	message(STATUS "Options for ${target}:")
-	message(STATUS "  PRIVATE: ${opts}")
-	message(STATUS "  INTERFACE: ${interface_opts}")
-endfunction()
-
-# Usage:
-message(STATUS "print_target_options-------------------------------")
-print_target_options(${PROJECT_NAME})
-message(STATUS "print_target_options-------------------------------")
 
 # Sanitizers.  @todo Make this a CMake option.
 #add_compile_options(-fsanitize=address)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,19 +223,20 @@ target_sources(libapp
                ${PROJECT_BINARY_DIR}/resources/VersionInfo.cpp
 )
 target_compile_definitions(libapp
-                           PRIVATE
-	                           # libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
-	                           # Enable the libstdc++ debug mode.
-	                           _GLIBCXX_DEBUG
-								-D_GLIBCXX_DEBUG_BACKTRACE
-	                           "KXMLGUI_NO_DEPRECATED=1"
+	PUBLIC
+		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
+		# Enable the libstdc++ debug mode.
+#		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+		"KXMLGUI_NO_DEPRECATED=1"
 )
 target_include_directories(libapp
 								PUBLIC
 									${PROJECT_SOURCE_DIR}/src ### @todo For <future/...>
 									${PROJECT_BINARY_DIR}/src
 )
-target_compile_options(libapp PUBLIC ${EXTRA_CXX_COMPILE_FLAGS})
+target_compile_options(libapp
+	PUBLIC
+		${EXTRA_CXX_COMPILE_FLAGS})
 set_target_properties(libapp
                       PROPERTIES
 	                      AUTOMOC ON
@@ -245,6 +246,7 @@ set_target_properties(libapp
 target_link_libraries(libapp
                       PUBLIC
 	                      # Targetized C++ compile settings.
+						cxx_compile_options
 	                      cxx_settings
 	                      cxx_definitions_qt
 	                      src
@@ -265,8 +267,7 @@ target_compile_definitions(${PROJECT_NAME}
 	PUBLIC
 		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
 		# Enable the libstdc++ debug mode.
-		_GLIBCXX_DEBUG
-		_GLIBCXX_DEBUG_BACKTRACE
+		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 		"KXMLGUI_NO_DEPRECATED=1"
 	)
 target_include_directories(${PROJECT_NAME}
@@ -286,12 +287,28 @@ set_target_properties(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
 	PUBLIC
 		# Targetized C++ compile settings.
+		cxx_compile_options
 		cxx_settings
 		cxx_definitions_qt
 	PRIVATE
 		libapp
 		stdc++exp # For debug backtrace in the std lib.
 )
+
+record_options(${PROJECT_NAME})
+
+function(print_target_options target)
+	get_target_property(opts ${target} COMPILE_OPTIONS)
+	get_target_property(interface_opts ${target} INTERFACE_COMPILE_OPTIONS)
+	message(STATUS "Options for ${target}:")
+	message(STATUS "  PRIVATE: ${opts}")
+	message(STATUS "  INTERFACE: ${interface_opts}")
+endfunction()
+
+# Usage:
+message(STATUS "print_target_options-------------------------------")
+print_target_options(${PROJECT_NAME})
+message(STATUS "print_target_options-------------------------------")
 
 # Sanitizers.  @todo Make this a CMake option.
 #add_compile_options(-fsanitize=address)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,9 +224,6 @@ target_sources(libapp
 )
 target_compile_definitions(libapp
 	PUBLIC
-		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
-		# Enable the libstdc++ debug mode.
-#		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 		"KXMLGUI_NO_DEPRECATED=1"
 )
 target_include_directories(libapp
@@ -265,9 +262,6 @@ qt_add_resources(
 )
 target_compile_definitions(${PROJECT_NAME}
 	PUBLIC
-		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
-		# Enable the libstdc++ debug mode.
-#		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 		"KXMLGUI_NO_DEPRECATED=1"
 	)
 target_include_directories(${PROJECT_NAME}

--- a/src/concurrency/DebugSequence.cpp
+++ b/src/concurrency/DebugSequence.cpp
@@ -19,6 +19,11 @@
 
 #include "DebugSequence.h"
 
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <atomic>
+
 DebugSequence::DebugSequence()
 {
 	// TODO Auto-generated constructor stub
@@ -28,5 +33,20 @@ DebugSequence::DebugSequence()
 DebugSequence::~DebugSequence()
 {
 	// TODO Auto-generated destructor stub
+}
+
+void DebugSequence::reset(int reset)
+{
+	m_expected_state = reset;
+}
+
+bool DebugSequence::expect_and_set(int expect, int set)
+{
+	int was = m_expected_state.exchange(set);
+    if (was != expect)
+	{
+		throw std::runtime_error("DebugSequence::expect_and_set: expected " + std::to_string(expect) + " but was " + std::to_string(was));
+	}
+	return was == expect;
 }
 

--- a/src/concurrency/DebugSequence.cpp
+++ b/src/concurrency/DebugSequence.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ * Copyright 2018, 2025 Gary R. Van Sickle (grvs@users.sourceforge.net).
  *
  * This file is part of AwesomeMediaLibraryManager.
  *

--- a/src/concurrency/DebugSequence.h
+++ b/src/concurrency/DebugSequence.h
@@ -20,19 +20,23 @@
 #ifndef SRC_CONCURRENCY_DEBUGSEQUENCE_H_
 #define SRC_CONCURRENCY_DEBUGSEQUENCE_H_
 
-/*
+/// @file
+
+#include <atomic>
+
+/**
  *
  */
 class DebugSequence
 {
+	std::atomic<int> m_expected_state {0};
+
 public:
 	DebugSequence();
-	virtual ~DebugSequence();
+	~DebugSequence();
 
-	enum SequencePoints
-	{
-
-	};
+	void reset(int reset);
+	bool expect_and_set(int expect, int set);
 };
 
 #endif /* SRC_CONCURRENCY_DEBUGSEQUENCE_H_ */

--- a/src/future/InsertionOrderedMap.h
+++ b/src/future/InsertionOrderedMap.h
@@ -73,7 +73,7 @@ private:
 	using uc_size_type = typename underlying_container_type::size_type;
 
 public:
-	M_GH_RULE_OF_FIVE_DEFAULT_C21(InsertionOrderedMap);
+	M_GH_RULE_OF_FIVE_DEFAULT_C21(InsertionOrderedMap)
 	~InsertionOrderedMap() = default;
 
 	// Copy-through-QVariant constructor.

--- a/src/future/guideline_helpers.h
+++ b/src/future/guideline_helpers.h
@@ -55,9 +55,9 @@
 	/** Copy assignment. */ \
 	classname& operator=(const classname&) = default_or_delete; \
 	/** Move constructor. */ \
-	classname(classname&&) = default_or_delete; \
+    classname(classname&&) noexcept = default_or_delete; \
 	/** Move assignment. */ \
-	classname& operator=(classname&&) = default_or_delete;
+    classname& operator=(classname&&) noexcept = default_or_delete;
 
 #define IMPL_RULE_OF_THREE(classname, default_or_delete) \
 /** Default constructor. */ \
@@ -75,9 +75,9 @@
 	/** Copy assignment. */ \
 	classname& operator=(const classname&) = default_or_delete; \
 	/** Move constructor. */ \
-	classname(classname &&) = default_or_delete; \
+    classname(classname &&) noexcept = default_or_delete; \
 	/** Move assignment. */ \
-	classname& operator=(classname &&) = default_or_delete;
+    classname& operator=(classname &&) noexcept = default_or_delete;
 
 ///
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1599,22 +1599,13 @@ void MainWindow::readLibSettings()
 	})
     .then(this, [this, overlay_filename, prog](QFuture<SerializableQVariantList> ef){
     	dseq.expect_and_set(2, 3);
-                                              qDb() << M_ID_VAL(ef.isValid());
-                                              if(!ef.isValid())
-                                              {
-                                              	qWr() << "XML Deserialization failed:" << overlay_filename;
-                                              	return;
-                                              }
-                                              SerializableQVariantList list;
-                                              qDb() << M_ID_VAL(list.m_uuid);
-                                              try {
-        /*SerializableQVariantList*/ list = ef.result();
-                                              }
-                                                  catch(QException& e)
-                                              {
-                                                  qFatal() << "Exception:" << e.what();
-                                                  Q_ASSERT(0);
-                                              }
+		if(!ef.isValid())
+		{
+			qWr() << "XML Deserialization failed:" << overlay_filename;
+			return;
+		}
+
+		SerializableQVariantList list = ef.result();
 
         qIn() << "###### READ" << list.size() << "libraries from XML DB:" << overlay_filename;
 

--- a/src/logic/AMLMTagMap.h
+++ b/src/logic/AMLMTagMap.h
@@ -50,7 +50,7 @@ Q_DECLARE_ASSOCIATIVE_CONTAINER_METATYPE(std::multimap);
  * Multimap of std::string key/std::string value pairs.
  * @todo Pretty sure this really should be an insertion-ordered multimap.
  */
-class AMLMTagMap final : public virtual ISerializable
+class AMLMTagMap final : public ISerializable
 {
 
 	/// @name Member Types

--- a/src/logic/CueSheet.h
+++ b/src/logic/CueSheet.h
@@ -74,7 +74,7 @@ class QUrl;
  * @sa https://isrc.ifpi.org/en/isrc-standard/structure
  *
  */
-class CueSheet : public virtual ISerializable
+class CueSheet final : public ISerializable
 {
 	Q_GADGET
 

--- a/src/logic/Library.h
+++ b/src/logic/Library.h
@@ -35,11 +35,11 @@
 
 class QFileDevice;
 
-class Library : public virtual ISerializable
+class Library final : public ISerializable
 {
 	Q_GADGET
 public:
-	M_GH_RULE_OF_FIVE_DEFAULT_C21(Library);
+    M_GH_RULE_OF_FIVE_DEFAULT_C21(Library)
 	~Library() override = default;
 
 	void clear();

--- a/src/logic/Metadata.h
+++ b/src/logic/Metadata.h
@@ -35,7 +35,7 @@
 #include <logic/serialization/ISerializable.h>
 
 
-class Metadata : public virtual ISerializable
+class Metadata final : public ISerializable
 {
 public:
     M_GH_RULE_OF_FIVE_DEFAULT_C21(Metadata)

--- a/src/logic/TrackIndex.h
+++ b/src/logic/TrackIndex.h
@@ -38,7 +38,7 @@ using Frames = qint64;
 //#include <third_party/libcue/libcue.h>
 #include "AMLMTagMap.h"
 
-class TrackIndex : public virtual ISerializable
+class TrackIndex final : public ISerializable
 {
 public:
 	M_GH_RULE_OF_FIVE_DEFAULT_C21(TrackIndex);

--- a/src/logic/TrackMetadata.h
+++ b/src/logic/TrackMetadata.h
@@ -47,7 +47,7 @@ using Frames = qint64;
 /**
  * Metadata which applies to a single track on a possibly multi-track media.
  */
-class TrackMetadata : public virtual ISerializable
+class TrackMetadata final : public ISerializable
 {
 public:
 	M_GH_RULE_OF_FIVE_DEFAULT_C21(TrackMetadata);

--- a/src/logic/serialization/ISerializable.cpp
+++ b/src/logic/serialization/ISerializable.cpp
@@ -48,6 +48,38 @@ AMLM_QREG_CALLBACK([](){
 });
 
 
+ISerializable::operator QVariant() const
+{
+	return toVariant();
+}
+
+bool ISerializable::isUuidNull() const
+{
+	return m_uuid.isNull() || m_uuid_prefix.empty();
+}
+
+std::string ISerializable::get_prefix() const
+{
+	return m_uuid_prefix;
+}
+
+std::string ISerializable::get_prefixed_uuid() const
+{
+	if(m_uuid.isNull())
+	{
+		// No valid prefix + UUID set.
+		return std::string();
+	}
+	return m_uuid_prefix + m_uuid.toString(QUuid::WithoutBraces).toStdString();
+}
+
+void ISerializable::set_prefixed_uuid(const std::string& uuid_string)
+{
+	m_uuid_prefix = "xmlid_"; ///< @todo
+	m_uuid = QUuid::fromString(toqstr(uuid_string).remove(toqstr(m_uuid_prefix)));
+	Q_ASSERT(!m_uuid.isNull());
+}
+
 QVariant SerializableQVariantList::toVariant() const
 {
 	Q_ASSERT(!m_list_tag.isNull());

--- a/src/logic/serialization/QVariantHomogenousList.cpp
+++ b/src/logic/serialization/QVariantHomogenousList.cpp
@@ -28,6 +28,7 @@
 
 // Ours
 #include <utils/RegisterQtMetatypes.h>
+#include <utils/DebugHelpers.h>
 
 AMLM_QREG_CALLBACK ([](){
  qIn() << "Registering QVariantHomogenousList";

--- a/src/logic/serialization/QVariantHomogenousList.h
+++ b/src/logic/serialization/QVariantHomogenousList.h
@@ -34,7 +34,7 @@
 #include <QList>
 
 // Ours.
-// #include <ISerializable.h> //<< This includes this file.
+// #include <ISerializable.h> //<< ISerializable.h includes this file.
 #include <future/guideline_helpers.h>
 
 

--- a/src/logic/serialization/QVariantHomogenousList.h
+++ b/src/logic/serialization/QVariantHomogenousList.h
@@ -30,10 +30,11 @@
 
 // Qt
 #include <QString>
+#include <QVariant>
+#include <QList>
 
 // Ours.
 // #include <ISerializable.h> //<< This includes this file.
-#include <utils/DebugHelpers.h>
 #include <future/guideline_helpers.h>
 
 
@@ -50,7 +51,7 @@ public:
 
 public:
 	// Rule-of-Zero doesn't work here, probably Qt.
-	M_GH_RULE_OF_FIVE_DEFAULT_C21(QVariantHomogenousList);
+	M_GH_RULE_OF_FIVE_DEFAULT_C21(QVariantHomogenousList)
 	virtual ~QVariantHomogenousList() = default;
 
 	QVariantHomogenousList(const QString& list_tag, const QString& list_item_tag)

--- a/src/logic/serialization/tests/XmlSerializerTest.cpp
+++ b/src/logic/serialization/tests/XmlSerializerTest.cpp
@@ -89,7 +89,7 @@ TEST_F(XmlSerializerTests, ShouldPass)
 
 
 
-TEST_F(XmlSerializerTests, TypeRoundTripping)
+TEST_F(XmlSerializerTests, DISABLED_TypeRoundTripping)
 {
 	// Round-tripped variant.
 	QVariantMap round_tripped_variant;

--- a/src/logic/serialization/tests/XmlSerializerTest.cpp
+++ b/src/logic/serialization/tests/XmlSerializerTest.cpp
@@ -89,7 +89,7 @@ TEST_F(XmlSerializerTests, ShouldPass)
 
 
 
-TEST_F(XmlSerializerTests, DISABLED_TypeRoundTripping)
+TEST_F(XmlSerializerTests, TypeRoundTripping)
 {
 	// Round-tripped variant.
 	QVariantMap round_tripped_variant;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,8 +20,6 @@
 
 #include <config.h>
 
-#include "AMLMApp.h"
-
 // Qt
 #include <QtGlobal>
 #include <QIcon>
@@ -45,6 +43,7 @@
 #endif
 
 // Ours
+#include "AMLMApp.h"
 #include "AMLMSettings.h"
 #include "Core.h"
 #include <gui/Theme.h>

--- a/src/utils/ConnectHelpers.cpp
+++ b/src/utils/ConnectHelpers.cpp
@@ -52,6 +52,6 @@ void Disconnector::disconnect()
     {
     	bool status = QObject::disconnect(connection);
         Q_ASSERT(status == true);
-        m_connections.clear();
     }
+	m_connections.clear();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,7 +113,7 @@ target_compile_definitions(${TEST_EXE_TARGET}
 		"GTEST_LANGUAGE_CXX11"
 		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
 		# Enable the libstdc++ debug mode.
-		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+#		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 )
 target_compile_options(${TEST_EXE_TARGET} PRIVATE ${EXTRA_CXX_COMPILE_FLAGS})
 set_target_properties(${TEST_EXE_TARGET} PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,16 +103,18 @@ target_include_directories(${TEST_EXE_TARGET}
                            # For config.h
                            ${PROJECT_BINARY_DIR}/src
 )
-#target_compile_features(${TEST_EXE_TARGET} PRIVATE cxx_relaxed_constexpr cxx_variable_templates)
+
 target_compile_definitions(${TEST_EXE_TARGET}
-                           PUBLIC
-                           # libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
-                           # Enable the libstdc++ debug mode.
-                           #_GLIBCXX_DEBUG
                            PRIVATE
-                           "TEST_FWK_IS_GTEST=1"
+                            "TEST_FWK_IS_GTEST=1"
 )
-target_compile_definitions(${TEST_EXE_TARGET} PRIVATE "GTEST_LANGUAGE_CXX11")
+target_compile_definitions(${TEST_EXE_TARGET}
+	PUBLIC
+		"GTEST_LANGUAGE_CXX11"
+		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
+		# Enable the libstdc++ debug mode.
+		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
+)
 target_compile_options(${TEST_EXE_TARGET} PRIVATE ${EXTRA_CXX_COMPILE_FLAGS})
 set_target_properties(${TEST_EXE_TARGET} PROPERTIES
                       AUTOMOC ON
@@ -128,10 +130,12 @@ set_property(TARGET gmock_main PROPERTY SKIP_AUTOGEN ON)
 target_link_libraries(${TEST_EXE_TARGET}
 	PUBLIC
 		# Targetized C++ compile settings.
+		cxx_compile_options
 		cxx_settings
 		# Qt-specific -D's.
 		cxx_definitions_qt
 	PRIVATE
+		stdc++exp
 #		Threads::Threads
 		gtest
 		gmock
@@ -142,7 +146,6 @@ target_link_libraries(${TEST_EXE_TARGET}
 		${PROJECT_COMMON_LINK_LIBS}
 #		${QT_LINK_LIB_TARGETS}
 		${KF_LINK_LIB_TARGETS}
-		stdc++exp
 )
 add_test(NAME ${TEST_EXE_TARGET} COMMAND $<TARGET_FILE:${TEST_EXE_TARGET}>)
 ecm_mark_as_test(${TEST_EXE_TARGET})
@@ -184,10 +187,12 @@ if(TRUE)
 	target_link_libraries(test_qtestamlmjobtests
 	                      PUBLIC
 							# Targetized C++ compile settings.
+							cxx_compile_options
 							cxx_settings
 							# Qt-specific -D's.
 							cxx_definitions_qt
 	                      PRIVATE
+								stdc++exp
 								utils
 								concurrency
 								logic
@@ -195,6 +200,7 @@ if(TRUE)
 								Qt6::Test
 								${PROJECT_COMMON_LINK_LIBS}
 								${KF_LINK_LIB_TARGETS}
+
 	)
 
 	add_test(NAME test_qtestamlmjobtests COMMAND $<TARGET_FILE:test_qtestamlmjobtests>)
@@ -222,6 +228,9 @@ target_include_directories(tests
 		${QtGui_PRIVATE_INCLUDE_DIRS}
 )
 target_link_libraries(tests
+	PUBLIC
+		cxx_compile_options
+		stdc++exp
 	PRIVATE
 		gtest
 		gmock

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,9 +111,6 @@ target_compile_definitions(${TEST_EXE_TARGET}
 target_compile_definitions(${TEST_EXE_TARGET}
 	PUBLIC
 		"GTEST_LANGUAGE_CXX11"
-		# libstdc++ defs: @link https://gcc.gnu.org/onlinedocs/gcc-9.1.0/libstdc++/manual/
-		# Enable the libstdc++ debug mode.
-#		$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_GLIBCXX_DEBUG;_GLIBCXX_DEBUG_BACKTRACE>
 )
 target_compile_options(${TEST_EXE_TARGET} PRIVATE ${EXTRA_CXX_COMPILE_FLAGS})
 set_target_properties(${TEST_EXE_TARGET} PROPERTIES


### PR DESCRIPTION
- Reworked compiler settings.
- New multitasking debug facility DebugSequence.
- Moved any non-template member functions in ISerializable.h to ISerializable.cpp.
- ISerializable: Changed a number of "public virtual" inheritances to non-virtual.  Finalized a number of ISerializable inheritors so we never run into the diamond problem.
- Bugfix in Disconnector::disconnect() where all connections would get clear()ed on the first disconnect iteration, vs after all disconnects were completed.
